### PR TITLE
Add CODEOWNERS and LICENSE

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @anthroarts/reg-extension

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Stephen Daily
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ Zip the build folder and your app is ready to be published on Chrome Web Store.
 `npm run test`
 
 Executes the files that contain unit tests.
+
+## Thanks!
+
+* ArcTheCollie - Initial development of the working extension
+* Kobaj
+* Cellivar Kangaroorat
+* Binaryfox


### PR DESCRIPTION
Does what it says on the tin.

The license comes from ArcTheCollie's version of the repo as they just updated it with a proper license. This repo continues to respect the license they chose, the MIT license.

At their request I've added a CODEOWNERS file and associated team, it will ping them on code reviews for as long as they'd like to be in the loop on that. That'll also help us be aware of when our review is requested, of course.

And finally I've added their info to the README.