### PR TITLE
Add GHA validation workflow for PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,10 @@ jobs:
       - run: npm ci --ignore-scripts
       - run: npm run test -- --reporter json --reporter-options output=test-results.json
       - name: Test Reporter
-        if: always()
+        if: success() || failure()
         uses: dorny/test-reporter@v1.5.0
         with:
+          name: 'Mocha Results'
           path: 'test-results.json'
           reporter: 'mocha-json'
           fail-on-error: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build on Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm ci --ignore-scripts
+      - run: npm run test -- --reporter json --reporter-options output=test-results.json
+      - name: Test Reporter
+        if: always()
+        uses: dorny/test-reporter@v1.5.0
+        with:
+          path: 'test-results.json'
+          reporter: 'mocha-json'
+          fail-on-error: 'true'
+
+

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,3 @@
+
+recursive: true
+require: 'mock-local-storage'

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "mocha ./test --recursive --require mock-local-storage",
+    "test": "mocha ./test",
     "watch": "webpack --mode=development --watch --config config/webpack.config.js",
     "build": "webpack --mode=production --config config/webpack.config.js"
   },

--- a/test/regfox/regfox_api.test.js
+++ b/test/regfox/regfox_api.test.js
@@ -27,6 +27,10 @@ describe('regfox_api', () => {
       expect(bearerToken).to.be.undefined;
     });
 
+    it('Always fails', () => {
+      expect(true).to.be.false;
+    })
+
     it('returns a good value', () => {
       const expectedToken = 'foxbutts';
       localStorage.setItem('wbcx_sessions', JSON.stringify({ '1311': { token: expectedToken } }));

--- a/test/regfox/regfox_api.test.js
+++ b/test/regfox/regfox_api.test.js
@@ -27,10 +27,6 @@ describe('regfox_api', () => {
       expect(bearerToken).to.be.undefined;
     });
 
-    it('Always fails', () => {
-      expect(true).to.be.false;
-    })
-
     it('returns a good value', () => {
       const expectedToken = 'foxbutts';
       localStorage.setItem('wbcx_sessions', JSON.stringify({ '1311': { token: expectedToken } }));


### PR DESCRIPTION
Should help us avoid surprises, especially as you add more tests to things.

This moves the mocha config over to a YAML file so that the test explorer extension I'm using works properly. It needed the config to be in a separate file as it doesn't read the package.json file.

![image](https://user-images.githubusercontent.com/1441553/146358669-53eb8075-df19-479f-81bb-4805e07b1b7b.png)

If you're curious [this is the extension I'm using](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter)