### PR TITLE
Add workflow screen state machine framework

### DIFF
--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  <div class="container-fluid container-no-gutter">
+  <div class="container-fluid container-no-gutter container-fullheight-with-navbar">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid container-no-gutter d-flex">
         <span class="navbar-brand me-auto" href="#">
@@ -53,23 +53,14 @@
         </div>
       </div>
     </nav>
-    <div class="row row-no-margin container-no-gutter">
-      <div id="buttonGutterLeft" class="col-2 d-grid gap-2 container-no-gutter">
-        <button id="cancelButton" class="btn btn-danger btn-fullheight">CANCEL</button>
+    <div class="row row-no-margin container-no-gutter h-100">
+      <div id="buttonGutterLeft" class="col-2 d-grid gap-2 h-100 container-no-gutter-left">
+        <button id="leftButton" class="btn btn-danger btn-fullheight btn-huge">CANCEL</button>
       </div>
-      <div class="col-8 pt-3">
-        <div class="row">
-          <div class="col-4 offset-4 d-grid gap-2 mb-3">
-            <button class="btn btn-primary" id="newSearch">🔎 New Search</button>
-          </div>
-        </div>
-        <div id="searchResults" class="row">
-          <!-- Demonstration canvas, actual layout will be different. -->
-          <canvas id="canvas" width="589" height="193" style="background-color: white; width: 589px; height: 193px; padding: 0;"></canvas>
-        </div>
+      <div class="col-8 pt-3" id="centerField">
       </div>
-      <div id="buttonGutterRight" class="col-2 d-grid gap-2 container-no-gutter">
-        <button id="printButton" class="btn btn-success btn-fullheight">PRINT</button>
+      <div id="buttonGutterRight" class="col-2 d-grid gap-2 h-100 container-no-gutter-right">
+        <button id="rightButton" class="btn btn-success btn-fullheight btn-huge">PRINT</button>
       </div>
     </div>
   </div>

--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -54,13 +54,38 @@
       </div>
     </nav>
     <div class="row row-no-margin container-no-gutter h-100">
-      <div id="buttonGutterLeft" class="col-2 d-grid gap-2 h-100 container-no-gutter-left">
-        <button id="leftButton" class="btn btn-danger btn-fullheight btn-huge">CANCEL</button>
+      <div class="col-2 d-grid gap-2 h-100 container-no-gutter-left">
+        <button id="cancelBtn" class="btn btn-danger btn-fullheight btn-huge">CANCEL</button>
       </div>
       <div class="col-8 pt-3" id="centerField">
+        <div id="newSearchState" class="row d-none">
+          <form class="row g-3" id="newSearchForm">
+            <div class="col-md-9">
+              <label for="newSearchText" class="form-label">Legal Name or Scan Barcode</label>
+              <input class="form-control form-control-lg" id="newSearchText" type="text" />
+            </div>
+            <div class="col-md-3 d-grid">
+              <button type="submit" class="btn btn-primary btn-lg" id="newSearchBtn">Search🔎</button>
+            </div>
+          </form>
+        </div>
+        <div id="loadingSearchResultState" class="row d-none">
+          <div class="col-md-8 offset-md-2"><h2>Searching for "<span id="loadingSearchText"></span>".</h2></div>
+          <div class="col-md-1">
+            <div class="spinner-border" role="status">
+              <span class="visually-hidden">Loading...</span>
+            </div>
+          </div>
+        </div>
+        <div id="singleResultState" class="row d-none">
+          <div id="searchResults" class="row">
+            <!-- Demonstration canvas, actual layout will be different. -->
+            <canvas id="canvas" width="589" height="193" style="background-color: white; width: 589px; height: 193px; padding: 0;"></canvas>
+          </div>
+        </div>
       </div>
-      <div id="buttonGutterRight" class="col-2 d-grid gap-2 h-100 container-no-gutter-right">
-        <button id="rightButton" class="btn btn-success btn-fullheight btn-huge">PRINT</button>
+      <div class="col-2 d-grid gap-2 h-100 container-no-gutter-right">
+        <button id="printBtn" class="btn btn-success btn-fullheight btn-huge">PRINT</button>
       </div>
     </div>
   </div>

--- a/public/regdesk_override.css
+++ b/public/regdesk_override.css
@@ -1,10 +1,33 @@
 
-.container-no-gutter {
+body {
+  height: 100vh;
+}
+
+.container-fullheight-with-navbar {
+  /* Height of bootstrap navbar is 56px */
+  height: calc(100% - 56px);
+}
+
+.container-no-gutter-left {
   padding-left: 0rem;
+}
+
+.container-no-gutter-right {
   padding-right: 0rem;
 }
 
 .row-no-margin {
   margin-left: 0rem;
   margin-right: 0rem;
+}
+
+.btn-huge {
+  font-size: 38pt;
+}
+
+.badge-canvas {
+  background-color: white;
+  width: 589px;
+  height: 193px;
+  padding: 0;
 }

--- a/src/regdesk/label_builder.js
+++ b/src/regdesk/label_builder.js
@@ -147,7 +147,7 @@ export class BadgeLabelBuilder {
    * Render this label's text onto a canvas, returning the ImageData.
    * @param {number} width - The width of the label.
    * @param {number} height - The height of the label.
-   * @param {CanvasRenderingContext2D} canvas - The optional canvas context to re-use.
+   * @param {HTMLCanvasElement} canvas - The optional canvas element to re-use.
    * If not supplied an OffscreenCanvas will be used instead.
    * @return {ImageData} - The ImageData of the canvas with the label's text rendered.
    */

--- a/src/regdesk/regdesk.js
+++ b/src/regdesk/regdesk.js
@@ -5,6 +5,8 @@ import { BadgeLabelBuilder } from './label_builder.js';
 import 'bootstrap';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-dark-5/dist/css/bootstrap-dark-plugin.min.css';
+import { RegMachineArgs } from './states/reg_machine_args.js';
+import { RegMachineManager } from './states/reg_machine_manager.js';
 
 /**
  * Configure the printer manager for this page
@@ -27,6 +29,7 @@ function configureManager({
 }
 
 let printerMgr;
+let regStateMachine;
 const fontLoader = BadgeLabelBuilder.loadCustomFonts(document);
 
 document.addEventListener('readystatechange', async () => {
@@ -35,21 +38,26 @@ document.addEventListener('readystatechange', async () => {
     await printerMgr.refreshPrinters();
     await fontLoader;
 
-    // ///////////////// Note!
-    // Demonstration code! This will work on -your- machine!
+    const stateArgs = RegMachineArgs.getFromDocument(document, printerMgr, null);
 
-    const canvas = document.getElementById('canvas');
-    const label = new BadgeLabelBuilder({
-      line1: 'A Furry 🍑',
-      line2: 'Just some furry name',
-      badgeId: '12345678',
-      level: 'Super Sponsor',
-      isMinor: false,
-    });
+    regStateMachine = new RegMachineManager(stateArgs);
+    await regStateMachine.transition(new CustomEvent('RESET'));
 
-    // You wouldn't normally call this directly, and instead use addToLabel like below
-    // Present here for demo purposes.
-    label.renderToImageData(canvas.width, canvas.height, canvas);
+    // // ///////////////// Note!
+    // // Demonstration code! This will work on -your- machine!
+
+    // const canvas = document.getElementById('canvas');
+    // const label = new BadgeLabelBuilder({
+    //   line1: 'A Furry 🍑',
+    //   line2: 'Just some furry name',
+    //   badgeId: '12345678',
+    //   level: 'Super Sponsor',
+    //   isMinor: false,
+    // });
+
+    // // You wouldn't normally call this directly, and instead use addToLabel like below
+    // // Present here for demo purposes.
+    // label.renderToImageData(canvas.width, canvas.height, canvas);
 
     // Demo of the more average use, commented out so I stop accidentally printing labels.
 

--- a/src/regdesk/regdesk.js
+++ b/src/regdesk/regdesk.js
@@ -41,7 +41,7 @@ document.addEventListener('readystatechange', async () => {
     const stateArgs = RegMachineArgs.getFromDocument(document, printerMgr, null);
 
     regStateMachine = new RegMachineManager(stateArgs);
-    await regStateMachine.transition(new CustomEvent('RESET'));
+    regStateMachine.transition(new CustomEvent('RESET'));
 
     // // ///////////////// Note!
     // // Demonstration code! This will work on -your- machine!

--- a/src/regdesk/states/loading_state.js
+++ b/src/regdesk/states/loading_state.js
@@ -3,7 +3,7 @@ import { RegState } from './reg_state.js';
 /**
  * Loading state
  */
-export class LoadingState extends RegState {
+export class LoadingSearchResultState extends RegState {
   /**
    * Get the transition events this state can process.
    */
@@ -22,7 +22,9 @@ export class LoadingState extends RegState {
    * @param {*} eventMap - Mapping of this object's transition events to new states.
    */
   constructor(regMachineArgs, eventMap) {
-    super(regMachineArgs, eventMap);
+    super(regMachineArgs, eventMap, 'loadingSearchResultState');
+
+    this.searchValueSpan = this.screenRow.querySelector('#loadingSearchText');
   }
 
   /**
@@ -30,15 +32,16 @@ export class LoadingState extends RegState {
    * @param {CustomEvent} e - The event details object.
    */
   enterState(e) {
-    this.leftButton.show().setTransitionCallback(this, LoadingState.events.CANCEL);
-    this.rightButton.hide();
+    this.show(this.screenRow);
+    this.cancelButton.visible().setTransitionCallback(this, LoadingSearchResultState.events.CANCEL);
+    this.printButton.invisible();
+
+    this.searchValueSpan.innerText = e.detail.searchText;
 
     // Demo code!
-    this.centerField.innerText = `Searching for ${e.detail.searchText}`;
-
     // Actually wait for results from commMgr instead of this lol.
     setTimeout(() => {
-      this.dispatchTransition(LoadingState.events.SINGLE_RESULT_READY);
+      this.dispatchTransition(LoadingSearchResultState.events.SINGLE_RESULT_READY, { badgeLine1: e.detail.searchText });
     }, 1000);
   }
 
@@ -46,6 +49,9 @@ export class LoadingState extends RegState {
    * Exit this state.
    */
   exitState() {
-    this.leftButton.clearTransitionCallback();
+    this.hide(this.screenRow);
+    this.cancelButton.clearTransitionCallback();
+
+    // TODO: cancel any in-progress searches!
   }
 }

--- a/src/regdesk/states/loading_state.js
+++ b/src/regdesk/states/loading_state.js
@@ -1,0 +1,51 @@
+import { RegState } from './reg_state.js';
+
+/**
+ * Loading state
+ */
+export class LoadingState extends RegState {
+  /**
+   * Get the transition events this state can process.
+   */
+  static get events() {
+    return {
+      CANCEL: 'CANCEL',
+      SINGLE_RESULT_READY: 'SINGLE_RESULT_READY',
+      MULTIPLE_RESULTS_READY: 'MULTIPLE_RESULTS_READY',
+      NO_RESULT_READY: 'NO_RESULT_READY',
+    };
+  }
+
+  /**
+   * Initializes a new instance of the LoadingState class.
+   * @param {RegMachineArgs} regMachineArgs - Standard argument set for states.
+   * @param {*} eventMap - Mapping of this object's transition events to new states.
+   */
+  constructor(regMachineArgs, eventMap) {
+    super(regMachineArgs, eventMap);
+  }
+
+  /**
+   * Actions to perform when entering the state.
+   * @param {CustomEvent} e - The event details object.
+   */
+  enterState(e) {
+    this.leftButton.show().setTransitionCallback(this, LoadingState.events.CANCEL);
+    this.rightButton.hide();
+
+    // Demo code!
+    this.centerField.innerText = `Searching for ${e.detail.searchText}`;
+
+    // Actually wait for results from commMgr instead of this lol.
+    setTimeout(() => {
+      this.dispatchTransition(LoadingState.events.SINGLE_RESULT_READY);
+    }, 1000);
+  }
+
+  /**
+   * Exit this state.
+   */
+  exitState() {
+    this.leftButton.clearTransitionCallback();
+  }
+}

--- a/src/regdesk/states/new_search_state.js
+++ b/src/regdesk/states/new_search_state.js
@@ -42,7 +42,7 @@ export class NewSearchState extends RegState {
    * Enter this state.
    */
   enterState() {
-    this.show(this.screenRow)
+    this.show(this.screenRow);
     this.cancelButton.invisible();
     this.printButton.invisible();
     this.searchInput.focus();

--- a/src/regdesk/states/new_search_state.js
+++ b/src/regdesk/states/new_search_state.js
@@ -22,44 +22,36 @@ export class NewSearchState extends RegState {
    */
   constructor(regMachineArgs, eventMap) {
     super(regMachineArgs, eventMap);
+
+    this.searchForm = this.screenRow.querySelector('#newSearchForm');
+    this.searchInput = this.screenRow.querySelector('#newSearchText');
+
+    // TODO: Figure out how to auto-trigger a search when a barcode is scanned.
+
+    this.searchForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      // Just to demonstrate the setup, this would talk to the commMgr
+      // and actually run the search.
+      // TODO: Should the event objects be strongly typed? Correlated somehow?
+      const searchText = this.searchInput.value;
+      this.dispatchTransition(NewSearchState.events.START_SEARCH, { searchText: searchText });
+    });
   }
 
   /**
    * Enter this state.
    */
   enterState() {
-    this.leftButton.hide();
-    this.rightButton.hide();
-
-    this.centerField.innerHTML = this.#getCenterTemplate();
-    this.centerField.querySelector('#newSearchText').focus();
-
-    // Search isn't wired up right now so instead we'll just transition
-    // to the loading screen.
-    this.centerField.querySelector('#newSearchButton')
-      .addEventListener('click', (e) => {
-        // Just to demonstrate the setup, this would talk to the commMgr
-        // and actually run the search.
-        // TODO: Should the event objects be strongly typed? Correlated somehow?
-        const searchText = this.centerField.querySelector('#newSearchText').value;
-        this.dispatchTransition(NewSearchState.events.START_SEARCH, { searchText: searchText });
-      });
+    this.show(this.screenRow)
+    this.cancelButton.invisible();
+    this.printButton.invisible();
+    this.searchInput.focus();
   }
 
   /**
-   *
-   * @return {string} - The center html elements.
+   * Exit this state
    */
-  #getCenterTemplate() {
-    return `
-<form class="row g-3" id="newSearchForm">
-  <div class="col-md-9">
-    <label for="newSearchText" class="form-label">Legal Name or Scan Barcode</label>
-    <input class="form-control form-control-lg" id="newSearchText" type="text" />
-  </div>
-  <div class="col-md-3 d-grid">
-    <button type="button" class="btn btn-primary btn-lg" id="newSearchButton">Search🔎</button>
-  </div>
-</form>`;
+  exitState() {
+    this.hide(this.screenRow);
   }
 }

--- a/src/regdesk/states/new_search_state.js
+++ b/src/regdesk/states/new_search_state.js
@@ -1,0 +1,65 @@
+import { RegState } from './reg_state.js';
+
+/**
+ * New Search state
+ */
+export class NewSearchState extends RegState {
+  /**
+   * Get the transition events this state can process.
+   */
+  static get events() {
+    // TODO: This is apparently how TS does enums, make it an enum someday?
+    return {
+      START_SEARCH: 'START_SEARCH',
+      RESET: 'RESET',
+    };
+  }
+
+  /**
+   * Initializes a new instance of the NewSearch class.
+   * @param {RegMachineArgs} regMachineArgs - Standard argument set for states.
+   * @param {*} eventMap - Mapping of this object's transition events to new states.
+   */
+  constructor(regMachineArgs, eventMap) {
+    super(regMachineArgs, eventMap);
+  }
+
+  /**
+   * Enter this state.
+   */
+  enterState() {
+    this.leftButton.hide();
+    this.rightButton.hide();
+
+    this.centerField.innerHTML = this.#getCenterTemplate();
+    this.centerField.querySelector('#newSearchText').focus();
+
+    // Search isn't wired up right now so instead we'll just transition
+    // to the loading screen.
+    this.centerField.querySelector('#newSearchButton')
+      .addEventListener('click', (e) => {
+        // Just to demonstrate the setup, this would talk to the commMgr
+        // and actually run the search.
+        // TODO: Should the event objects be strongly typed? Correlated somehow?
+        const searchText = this.centerField.querySelector('#newSearchText').value;
+        this.dispatchTransition(NewSearchState.events.START_SEARCH, { searchText: searchText });
+      });
+  }
+
+  /**
+   *
+   * @return {string} - The center html elements.
+   */
+  #getCenterTemplate() {
+    return `
+<form class="row g-3" id="newSearchForm">
+  <div class="col-md-9">
+    <label for="newSearchText" class="form-label">Legal Name or Scan Barcode</label>
+    <input class="form-control form-control-lg" id="newSearchText" type="text" />
+  </div>
+  <div class="col-md-3 d-grid">
+    <button type="button" class="btn btn-primary btn-lg" id="newSearchButton">Search🔎</button>
+  </div>
+</form>`;
+  }
+}

--- a/src/regdesk/states/reg_machine_args.js
+++ b/src/regdesk/states/reg_machine_args.js
@@ -1,0 +1,49 @@
+import { WorkflowButton } from '../workflow_button.js';
+
+/**
+ * Record for the common state machine args for states.
+ */
+export class RegMachineArgs {
+  /**
+   * Initializes a new instance of the RegMachineArgs class.
+   * @param {WorkflowButton} leftButton - The left side gutter button.
+   * @param {WorkflowButton} rightButton - The right side gutter button.
+   * @param {Element} centerField - The center container for page content.
+   * @param {PrinterManager} printerManager - The printer manager that manages printers.
+   * @param {CommunicationManager} commManager - The communication manager for making API calls.
+   */
+  constructor(
+    leftButton,
+    rightButton,
+    centerField,
+    printerManager,
+    commManager,
+  ) {
+    this.leftButton = leftButton;
+    this.rightButton = rightButton;
+    this.centerField = centerField;
+    this.printerManager = printerManager;
+    this.commManager = commManager;
+
+    if (this.constructor === RegMachineArgs.constructor) {
+      Object.freeze(this);
+    }
+  }
+
+  /**
+   * Get a new RegMachineArgs by querying the document directly.
+   * @param {Document} document - Document object to get elements from.
+   * @param {PrinterManager} printerManager - The printer manager to use.
+   * @param {CommunicationManager} commManager - The comm manager to use.
+   * @return {RegMachineArgs} - The constructed object.
+   */
+  static getFromDocument(document, printerManager, commManager) {
+    return new RegMachineArgs(
+      new WorkflowButton(document.getElementById('leftButton')),
+      new WorkflowButton(document.getElementById('rightButton')),
+      document.getElementById('centerField'),
+      printerManager,
+      commManager,
+    );
+  }
+}

--- a/src/regdesk/states/reg_machine_args.js
+++ b/src/regdesk/states/reg_machine_args.js
@@ -6,21 +6,21 @@ import { WorkflowButton } from '../workflow_button.js';
 export class RegMachineArgs {
   /**
    * Initializes a new instance of the RegMachineArgs class.
-   * @param {WorkflowButton} leftButton - The left side gutter button.
-   * @param {WorkflowButton} rightButton - The right side gutter button.
+   * @param {WorkflowButton} cancelBtn - The left side gutter button.
+   * @param {WorkflowButton} printBtn - The right side gutter button.
    * @param {Element} centerField - The center container for page content.
    * @param {PrinterManager} printerManager - The printer manager that manages printers.
    * @param {CommunicationManager} commManager - The communication manager for making API calls.
    */
   constructor(
-    leftButton,
-    rightButton,
+    cancelBtn,
+    printBtn,
     centerField,
     printerManager,
     commManager,
   ) {
-    this.leftButton = leftButton;
-    this.rightButton = rightButton;
+    this.cancelButton = cancelBtn;
+    this.printButton = printBtn;
     this.centerField = centerField;
     this.printerManager = printerManager;
     this.commManager = commManager;
@@ -39,8 +39,8 @@ export class RegMachineArgs {
    */
   static getFromDocument(document, printerManager, commManager) {
     return new RegMachineArgs(
-      new WorkflowButton(document.getElementById('leftButton')),
-      new WorkflowButton(document.getElementById('rightButton')),
+      new WorkflowButton(document.getElementById('cancelBtn')),
+      new WorkflowButton(document.getElementById('printBtn')),
       document.getElementById('centerField'),
       printerManager,
       commManager,

--- a/src/regdesk/states/reg_machine_manager.js
+++ b/src/regdesk/states/reg_machine_manager.js
@@ -78,6 +78,7 @@ export class RegMachineManager {
    * Apply the transition of an event to the current state.
    * @param {CustomEvent} event - The event triggered on the current state.
    * @param {RegState} state - The current state.
+   * @return {string} - The resulting state.
    */
   transition(event, state = this.#currentState) {
     console.log('TRANSITION!', event);

--- a/src/regdesk/states/reg_machine_manager.js
+++ b/src/regdesk/states/reg_machine_manager.js
@@ -1,4 +1,4 @@
-import { LoadingState } from './loading_state.js';
+import { LoadingSearchResultState } from './loading_state.js';
 import { NewSearchState } from './new_search_state.js';
 import { SingleResultState } from './single_result_state.js';
 
@@ -36,16 +36,16 @@ export class RegMachineManager {
     // TODO: Is there a better way to store this?
     const eventMap = [
       {
-        type: LoadingState,
+        type: LoadingSearchResultState,
         events: {
-          [LoadingState.events.CANCEL]: NewSearchState.name,
-          [LoadingState.events.SINGLE_RESULT_READY]: SingleResultState.name,
+          [LoadingSearchResultState.events.CANCEL]: NewSearchState.name,
+          [LoadingSearchResultState.events.SINGLE_RESULT_READY]: SingleResultState.name,
         },
       },
       {
         type: NewSearchState,
         events: {
-          [NewSearchState.events.START_SEARCH]: LoadingState.name,
+          [NewSearchState.events.START_SEARCH]: LoadingSearchResultState.name,
           [NewSearchState.events.RESET]: NewSearchState.name,
         },
       },
@@ -66,7 +66,7 @@ export class RegMachineManager {
 
       for (const [eventName] of Object.entries(state.events)) {
         machine.states[state.type.name]
-          .addEventListener(eventName, async (e) => await this.transition(e));
+          .addEventListener(eventName, (e) => this.transition(e));
       }
     });
 
@@ -79,7 +79,7 @@ export class RegMachineManager {
    * @param {CustomEvent} event - The event triggered on the current state.
    * @param {RegState} state - The current state.
    */
-  async transition(event, state = this.#currentState) {
+  transition(event, state = this.#currentState) {
     console.log('TRANSITION!', event);
     const nextStateName = this.#machine
       .states[state]

--- a/src/regdesk/states/reg_machine_manager.js
+++ b/src/regdesk/states/reg_machine_manager.js
@@ -1,0 +1,106 @@
+import { LoadingState } from './loading_state.js';
+import { NewSearchState } from './new_search_state.js';
+import { SingleResultState } from './single_result_state.js';
+
+/**
+ * State mchine manager for the reg lookup interface.
+ */
+export class RegMachineManager {
+  /**
+   * Stores the state machine.
+   */
+  #machine;
+
+  /**
+   * Gets the state machine for this machine
+   */
+  get machine() {
+    return this.#machine;
+  }
+
+  /**
+   * Stores the current state of the machine.
+   */
+  #currentState;
+
+  /**
+   * Initializes a new instance of the RegMachineManager class.
+   * @param {RegMachineArgs} regMachineArgs - The standard record for each state class.
+   */
+  constructor(regMachineArgs) {
+    const machine = {
+      initial: NewSearchState.name,
+      states: {},
+    };
+
+    // TODO: Is there a better way to store this?
+    const eventMap = [
+      {
+        type: LoadingState,
+        events: {
+          [LoadingState.events.CANCEL]: NewSearchState.name,
+          [LoadingState.events.SINGLE_RESULT_READY]: SingleResultState.name,
+        },
+      },
+      {
+        type: NewSearchState,
+        events: {
+          [NewSearchState.events.START_SEARCH]: LoadingState.name,
+          [NewSearchState.events.RESET]: NewSearchState.name,
+        },
+      },
+      {
+        type: SingleResultState,
+        events: {
+          [SingleResultState.events.CANCEL]: NewSearchState.name,
+        },
+      },
+    ];
+
+    // TODO: Probably a way to merge the event map with the machine declaration
+    // whem I'm not mentally fried on my third flight of the day.
+    eventMap.forEach((state) => {
+      // Interesting, eslint doesn't handle this correctly.
+      // eslint-disable-next-line new-cap
+      machine.states[state.type.name] = new state.type(regMachineArgs, state.events);
+
+      for (const [eventName] of Object.entries(state.events)) {
+        machine.states[state.type.name]
+          .addEventListener(eventName, async (e) => await this.transition(e));
+      }
+    });
+
+    this.#machine = machine;
+    this.#currentState = machine.initial;
+  }
+
+  /**
+   * Apply the transition of an event to the current state.
+   * @param {CustomEvent} event - The event triggered on the current state.
+   * @param {RegState} state - The current state.
+   */
+  async transition(event, state = this.#currentState) {
+    console.log('TRANSITION!', event);
+    const nextStateName = this.#machine
+      .states[state]
+      .eventMap?.[event.type] ??
+      state;
+
+    try {
+      this.#machine.states[state]?.exitState?.(event);
+    } catch (e) {
+      // TODO: Display an error or something.
+      console.error(`Failed to run actions from ${state} exit event ${event.type}.`, e);
+    }
+
+    try {
+      this.#machine.states[nextStateName]?.enterState?.(event);
+    } catch (e) {
+      // TODO: Display an error or something.
+      console.error(`Failed to run actions from ${state} enter event ${event.type}.`, e);
+    }
+
+    this.#currentState = nextStateName;
+    return this.#currentState;
+  }
+}

--- a/src/regdesk/states/reg_state.js
+++ b/src/regdesk/states/reg_state.js
@@ -1,0 +1,84 @@
+// eslint-disable-next-line no-unused-vars
+import { RegMachineArgs } from './reg_machine_args.js';
+
+/**
+ * Basic state class
+ */
+export class RegState extends EventTarget {
+  #regMachineArgs;
+
+  /**
+   * Get the left gutter button
+   */
+  get leftButton() {
+    return this.#regMachineArgs.leftButton;
+  }
+
+  /**
+   * Get the right gutter button.
+   */
+  get rightButton() {
+    return this.#regMachineArgs.rightButton;
+  }
+
+  /**
+   * Get the center field of the page display.
+   */
+  get centerField() {
+    return this.#regMachineArgs.centerField;
+  }
+
+  /**
+   * Get the PrinterManager
+   */
+  get printerManager() {
+    return this.#regMachineArgs.printerManager;
+  }
+
+  /**
+   * Get the CommunicationManager
+   */
+  get commManager() {
+    return this.#regMachineArgs.commManager;
+  }
+
+  #eventMap;
+  /**
+   * Get the event map for this state.
+   */
+  get eventMap() {
+    return this.#eventMap;
+  }
+
+  /**
+   * Initializes a new instance of the RegState class.
+   * @param {RegMachineArgs} regMachineArgs - The reg state machine args.
+   * @param {*} eventMap - Mapping of this object's transition events to new states.
+   */
+  constructor(regMachineArgs, eventMap) {
+    super();
+    // TODO: Make this a Map()?
+    this.#eventMap = eventMap;
+    this.#regMachineArgs = regMachineArgs;
+  }
+
+  /**
+   * Dispatch a transition event off of this state.
+   * @param {string} eventName - The transition event being dispatched
+   * @param {*} details - The details object to attach to the event
+   */
+  dispatchTransition(eventName, details) {
+    const event = new CustomEvent(eventName, { detail: details });
+    this.dispatchEvent(event);
+  }
+
+  /**
+   * No-op when entering the state.
+   */
+  enterState() {}
+
+  /**
+   * No-op when exiting the state.
+   */
+  exitState() {}
+}

--- a/src/regdesk/states/reg_state.js
+++ b/src/regdesk/states/reg_state.js
@@ -35,7 +35,7 @@ export class RegState extends EventTarget {
     return this.#regMachineArgs.commManager;
   }
 
-  #screenRow
+  #screenRow;
   /**
    * Get the HTML div this reg state manages.
    */
@@ -65,7 +65,7 @@ export class RegState extends EventTarget {
     // Assumed convention: The CSS ID of the HTML element under management is the
     // class name, but with the first character lowercased
     const className = this.constructor.name;
-    const cssId = "#" + className.charAt(0).toLowerCase() + className.slice(1);
+    const cssId = '#' + className.charAt(0).toLowerCase() + className.slice(1);
     this.#screenRow = regMachineArgs.centerField.querySelector(cssId);
   }
 

--- a/src/regdesk/states/reg_state.js
+++ b/src/regdesk/states/reg_state.js
@@ -8,38 +8,39 @@ export class RegState extends EventTarget {
   #regMachineArgs;
 
   /**
-   * Get the left gutter button
+   * Get the cancel gutter button.
    */
-  get leftButton() {
-    return this.#regMachineArgs.leftButton;
+  get cancelButton() {
+    return this.#regMachineArgs.cancelButton;
   }
 
   /**
-   * Get the right gutter button.
+   * Get the print gutter button.
    */
-  get rightButton() {
-    return this.#regMachineArgs.rightButton;
+  get printButton() {
+    return this.#regMachineArgs.printButton;
   }
 
   /**
-   * Get the center field of the page display.
-   */
-  get centerField() {
-    return this.#regMachineArgs.centerField;
-  }
-
-  /**
-   * Get the PrinterManager
+   * Get the PrinterManager.
    */
   get printerManager() {
     return this.#regMachineArgs.printerManager;
   }
 
   /**
-   * Get the CommunicationManager
+   * Get the CommunicationManager.
    */
   get commManager() {
     return this.#regMachineArgs.commManager;
+  }
+
+  #screenRow
+  /**
+   * Get the HTML div this reg state manages.
+   */
+  get screenRow() {
+    return this.#screenRow;
   }
 
   #eventMap;
@@ -60,6 +61,12 @@ export class RegState extends EventTarget {
     // TODO: Make this a Map()?
     this.#eventMap = eventMap;
     this.#regMachineArgs = regMachineArgs;
+
+    // Assumed convention: The CSS ID of the HTML element under management is the
+    // class name, but with the first character lowercased
+    const className = this.constructor.name;
+    const cssId = "#" + className.charAt(0).toLowerCase() + className.slice(1);
+    this.#screenRow = regMachineArgs.centerField.querySelector(cssId);
   }
 
   /**
@@ -81,4 +88,24 @@ export class RegState extends EventTarget {
    * No-op when exiting the state.
    */
   exitState() {}
+
+  /**
+   * Show any elements hidden with hide.
+   * @param  {...Element} elements - The elements to show.
+   */
+  show(...elements) {
+    elements.forEach((e) => {
+      e.classList.remove('d-none');
+    });
+  }
+
+  /**
+   * Display-none elements.
+   * @param  {...Element} elements - The elements to hide.
+   */
+  hide(...elements) {
+    elements.forEach((e) => {
+      e.classList.add('d-none');
+    });
+  }
 }

--- a/src/regdesk/states/single_result_state.js
+++ b/src/regdesk/states/single_result_state.js
@@ -22,44 +22,38 @@ export class SingleResultState extends RegState {
    */
   constructor(regMachineArgs, eventMap) {
     super(regMachineArgs, eventMap);
+
+    this.canvas = this.screenRow.querySelector('#canvas');
   }
 
   /**
    * Enter this state.
+   * @param {CustomEvent} e - The event details object.
    */
-  enterState() {
-    this.leftButton.show().setTransitionCallback(this, SingleResultState.events.CANCEL);
-    this.rightButton.show();
+  enterState(e) {
+    this.show(this.screenRow);
+    this.cancelButton.visible().setTransitionCallback(this, SingleResultState.events.CANCEL);
+    this.printButton.visible();
 
     // More demo code! This would be pulled from commMgr or the event details.
-    this.centerField.innerHTML = this.#getCenterTemplate();
-    const canvas = this.centerField.querySelector('canvas');
+    const ctx = this.canvas.getContext('2d');
+    ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+
     const label = new BadgeLabelBuilder({
-      line1: 'EXAMPLE',
+      line1: e.detail.badgeLine1,
       line2: 'Just an example',
       badgeId: '12345678',
       level: 'Super Sponsor',
       isMinor: false,
     });
-    label.renderToImageData(canvas.width, canvas.height, canvas);
+    label.renderToImageData(this.canvas.width, this.canvas.height, this.canvas);
   }
 
   /**
    * Exit this state.
    */
   exitState() {
-    this.leftButton.clearTransitionCallback();
-  }
-
-  /**
-   * Get the center field template.
-   * @return {string} - innerHTML for the centerField.
-   */
-  #getCenterTemplate() {
-    return `
-<div id="searchResults" class="row">
-  <!-- Demonstration canvas, actual layout will be different. -->
-  <canvas id="canvas" width="589" height="193" style="background-color: white; width: 589px; height: 193px; padding: 0;"></canvas>
-</div>`;
+    this.hide(this.screenRow);
+    this.cancelButton.clearTransitionCallback();
   }
 }

--- a/src/regdesk/states/single_result_state.js
+++ b/src/regdesk/states/single_result_state.js
@@ -1,0 +1,65 @@
+import { RegState } from './reg_state.js';
+
+import { BadgeLabelBuilder } from '../label_builder.js';
+
+/**
+ * Loading state
+ */
+export class SingleResultState extends RegState {
+  /**
+   * Get the transition events this state can process.
+   */
+  static get events() {
+    return {
+      CANCEL: 'CANCEL',
+    };
+  }
+
+  /**
+   * Initializes a new instance of the SingleResultState class.
+   * @param {RegMachineArgs} regMachineArgs - Standard argument set for states.
+   * @param {*} eventMap - Mapping of this object's transition events to new states.
+   */
+  constructor(regMachineArgs, eventMap) {
+    super(regMachineArgs, eventMap);
+  }
+
+  /**
+   * Enter this state.
+   */
+  enterState() {
+    this.leftButton.show().setTransitionCallback(this, SingleResultState.events.CANCEL);
+    this.rightButton.show();
+
+    // More demo code! This would be pulled from commMgr or the event details.
+    this.centerField.innerHTML = this.#getCenterTemplate();
+    const canvas = this.centerField.querySelector('canvas');
+    const label = new BadgeLabelBuilder({
+      line1: 'EXAMPLE',
+      line2: 'Just an example',
+      badgeId: '12345678',
+      level: 'Super Sponsor',
+      isMinor: false,
+    });
+    label.renderToImageData(canvas.width, canvas.height, canvas);
+  }
+
+  /**
+   * Exit this state.
+   */
+  exitState() {
+    this.leftButton.clearTransitionCallback();
+  }
+
+  /**
+   * Get the center field template.
+   * @return {string} - innerHTML for the centerField.
+   */
+  #getCenterTemplate() {
+    return `
+<div id="searchResults" class="row">
+  <!-- Demonstration canvas, actual layout will be different. -->
+  <canvas id="canvas" width="589" height="193" style="background-color: white; width: 589px; height: 193px; padding: 0;"></canvas>
+</div>`;
+  }
+}

--- a/src/regdesk/workflow_button.js
+++ b/src/regdesk/workflow_button.js
@@ -28,7 +28,7 @@ export class WorkflowButton {
    * Hide this button.
    * @return {WorkflowButton} - This button.
    */
-  hide() {
+  invisible() {
     this.#element.classList.remove('visible');
     this.#element.classList.add('invisible');
     return this;
@@ -38,7 +38,7 @@ export class WorkflowButton {
    * Show this button
    * @return {WorkflowButton} - This button.
    */
-  show() {
+  visible() {
     this.#element.classList.remove('invisible');
     this.#element.classList.add('visible');
     return this;

--- a/src/regdesk/workflow_button.js
+++ b/src/regdesk/workflow_button.js
@@ -1,0 +1,100 @@
+// eslint-disable-next-line no-unused-vars
+import { RegState } from './states/reg_state.js';
+
+/**
+ * Wrapper for one of the side gutter buttons for navigating workflows
+ */
+export class WorkflowButton {
+  #element;
+
+  /**
+   * @type {RegState}
+   */
+  #transitionEventTarget;
+  #transitionEvent;
+  #transitionEventDetails;
+
+  #buttonClickEvent = 'click';
+
+  /**
+   * Initializes a new instance of the WorkflowButton class.
+   * @param {Element} buttonElement - The button to wrap
+   */
+  constructor(buttonElement) {
+    this.#element = buttonElement;
+  }
+
+  /**
+   * Hide this button.
+   * @return {WorkflowButton} - This button.
+   */
+  hide() {
+    this.#element.classList.remove('visible');
+    this.#element.classList.add('invisible');
+    return this;
+  }
+
+  /**
+   * Show this button
+   * @return {WorkflowButton} - This button.
+   */
+  show() {
+    this.#element.classList.remove('invisible');
+    this.#element.classList.add('visible');
+    return this;
+  }
+
+  /**
+   * Remove the transition callback registered on the button.
+   * @return {WorkflowButton} - This button.
+   */
+  clearTransitionCallback() {
+    this.#transitionEventTarget = undefined;
+    this.#transitionEvent = undefined;
+    this.#transitionEventDetails = undefined;
+    this.#element.removeEventListener(this.#buttonClickEvent, this.handleClickEvent);
+    return this;
+  }
+
+  /**
+   * Register a transition event for this button to fire on a click.
+   * Overwrites any existing transitions.
+   * @param {RegState} transitionEventSender - The object to send the event through
+   * @param {string} event - The event name to send
+   * @param {*} details - Optional details object to add to the event.
+   * @return {WorkflowButton} - This button.
+   */
+  setTransitionCallback(transitionEventSender, event, details) {
+    this.clearTransitionCallback();
+    this.#transitionEventTarget = transitionEventSender;
+    this.#transitionEvent = event;
+    this.#transitionEventDetails = details;
+    this.#element.addEventListener(this.#buttonClickEvent, this.handleClickEvent.bind(this));
+    return this;
+  }
+
+  /**
+   * Dispatch a click event, if relevant to do so.
+   *
+   * @description Okay but why though? So we can remove this event listener.
+   * Event listeners are identified by the _combination_ of their event, such as
+   * 'click', _and_ the _specific_ handler function passed in. See the docs:
+   * https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#matching_event_listeners_for_removal
+   * Anonymous functions, the ususal way of writing handler methods are abnonymous.
+   * Once you send them off to handle the event you can't find them again. Therefore
+   * you can't _remove_ that event handler if you need to for any reason.
+   * The two options boil down to either "replace the element with a clone which
+   * strips the event handlers" or "keep track of your event handlers". This class
+   * is how we implemented the latter.
+   * Sidenote this is what a "remarks" field is for and I miss it.
+   */
+  handleClickEvent() {
+    if (this.#transitionEventTarget) {
+      // Only should be attempted if we acutally have a target.
+      this.#transitionEventTarget.dispatchTransition(
+        this.#transitionEvent,
+        this.#transitionEventDetails,
+      );
+    }
+  }
+}


### PR DESCRIPTION
Okay so [I read a thing](https://dev.to/davidkpiano/you-don-t-need-a-library-for-state-machines-k7h) and pulled some ideas from it.

Our workflow for cashier processing can be broken down into a fairly straightforward workflow without a lot of looping and complex operations. I'm working on adding a _complete_ workflow diagram of the workflows we need to support. A complete workflow is something we can represent as a state machine.

So I implemented a state machine.

The basic idea is that each state class encapsulates the necessary stuff to wire up the screen to do whatever that step of the workflow is capable of doing. In this PR are three example classes that handle search, waiting for search results to return, and then displaying the result. The search to loading transition also demonstrates support for arbitrary data transfer across a transition boundary.

We handle the transitions via events to better ensure no circular dependency references. 

The entire state machine graph will be described in the state machine manager class. I'm not 100% on this solution and am open to ideas on a better representation.

I'm submitting this so I can go to bed.