### PR TITLE
Add KIT badge print button

### DIFF
--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -28,6 +28,8 @@
                 <span id="minorPrintIcon">❌</span> Minor <span id="minorPrintName">(No Printer)</span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <li id="minorPrintKit"><a class="dropdown-item" href="#">Print KIT badge</a></li>
+                <li><hr class="dropdown-divider"/></li>
                 <li id="minorPrintConnect"><a class="dropdown-item" href="#">Connect</a></li>
                 <li id="minorPrintDisconnect"><a class="dropdown-item" href="#">Disconnect</a></li>
                 <li id="minorPrintTest"><a class="dropdown-item" href="#">Print Test Page</a></li>

--- a/src/regdesk/label_builder.js
+++ b/src/regdesk/label_builder.js
@@ -134,7 +134,7 @@ export class BadgeLabelBuilder {
   renderToImageSizedToLabel(width, height, widthPadding = 20, heightPadding = 10) {
     // Safety buffer around the edges of the printable area.
     // Make sure the width ends up on an byte boundary!
-    const widthRemainder = (label.labelWidthDots - widthPadding) % 8;
+    const widthRemainder = (width - widthPadding) % 8;
     const widthOffset = widthPadding + widthRemainder;
     const canvasData = this.renderToImageData(
       width - widthOffset,

--- a/src/regdesk/printer_dropdown.js
+++ b/src/regdesk/printer_dropdown.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-unused-vars
-import { LabelEpl } from "webzlp/src/LabelEpl";
+import { LabelEpl } from 'webzlp/src/LabelEpl';
 // eslint-disable-next-line no-unused-vars
-import { LP2844 } from "webzlp/src/LP2844";
+import { LP2844 } from 'webzlp/src/LP2844';
 
 /**
  * Class for managing a printer dropdown

--- a/src/regdesk/printer_dropdown.js
+++ b/src/regdesk/printer_dropdown.js
@@ -1,8 +1,21 @@
+// eslint-disable-next-line no-unused-vars
+import { LabelEpl } from "webzlp/src/LabelEpl";
+// eslint-disable-next-line no-unused-vars
+import { LP2844 } from "webzlp/src/LP2844";
 
 /**
  * Class for managing a printer dropdown
  */
 export class PrinterDropdown extends EventTarget {
+  /**
+   * Get the events this dropdown can generate.
+   */
+  static get events() {
+    return {
+      CONNECT_PRINTER: 'CONNECT_PRINTER',
+      PRINT_KIT_BADGE: 'PRINT_KIT_BADGE',
+    };
+  }
   /**
    * The printer displayed by this class.
    * @type {LP2844}
@@ -37,6 +50,8 @@ export class PrinterDropdown extends EventTarget {
   #feedPrintElement;
   // Button for showing the config dialog
   #configElement;
+  // Button for printing a KIT badge
+  #kitBadgeElement;
 
   /**
    * Initializes a new instance of the PrinterDropdown class.
@@ -50,6 +65,7 @@ export class PrinterDropdown extends EventTarget {
    * @param {Element} o.testElement - The print test page button.
    * @param {Element} o.feedElement - The feed label button.
    * @param {Element} o.configElement - The configure dialog button.
+   * @param {Element} o.kitBadgeElement - The print KIT badge element.
    */
   constructor({
     dropdownName,
@@ -60,6 +76,7 @@ export class PrinterDropdown extends EventTarget {
     testElement,
     feedElement,
     configElement,
+    kitBadgeElement,
   }) {
     super();
 
@@ -83,6 +100,9 @@ export class PrinterDropdown extends EventTarget {
     this.#configElement = configElement;
     this.#connectElement.addEventListener('click', () => this.showConfig());
 
+    this.#kitBadgeElement = kitBadgeElement;
+    this.#kitBadgeElement?.addEventListener('click', () => this.#printKitBadge());
+
     // Safe to call this without an await because there won't be a printer yet.
     // TODO: kinda makes me itchy though.
     this.removePrinter();
@@ -92,9 +112,15 @@ export class PrinterDropdown extends EventTarget {
    * Request a connection for htis printer.
    */
   #connectPrinter() {
-    const event = new CustomEvent(
-      this.constructor.ConnectEventName,
-      { target: this });
+    const event = new CustomEvent(this.constructor.events.CONNECT_PRINTER);
+    this.dispatchEvent(event);
+  }
+
+  /**
+   * Request to print a kid-in-tow badge.
+   */
+  #printKitBadge() {
+    const event = new CustomEvent(this.constructor.events.PRINT_KIT_BADGE);
     this.dispatchEvent(event);
   }
 
@@ -119,6 +145,7 @@ export class PrinterDropdown extends EventTarget {
     this.#printerNameElement.textContent = '(No Printer)';
     this.#show(this.#connectElement);
     this.#hide(
+      this.#kitBadgeElement,
       this.#disconnectElement,
       this.#testPrintElement,
       this.#feedPrintElement,
@@ -137,11 +164,24 @@ export class PrinterDropdown extends EventTarget {
     this.#printerNameElement.textContent = `(${this.#printer.serial})`;
     this.#hide(this.#connectElement);
     this.#show(
+      this.#kitBadgeElement,
       this.#disconnectElement,
       this.#testPrintElement,
       this.#feedPrintElement,
       this.#configElement,
     );
+  }
+
+  /**
+   * Print a label to this managed printer
+   * @param {LabelEpl} label - The label to print
+   */
+  async printLabel(label) {
+    if (!this.#printer) {
+      console.error('No printer selected, can\'t print test page.');
+    }
+
+    return this.#printer.printLabel(label);
   }
 
   /**
@@ -183,12 +223,12 @@ export class PrinterDropdown extends EventTarget {
 
   /**
    * Hide all elements shown by #show.
-   * @param  {...any} elements - The elements to hide.
+   * @param  {...Element} elements - The elements to hide.
    */
   #hide(...elements) {
     elements.forEach((e) => {
-      e.classList.remove('visible');
-      e.classList.add('invisible');
+      e?.classList.remove('visible');
+      e?.classList.add('invisible');
     });
   }
 
@@ -198,16 +238,9 @@ export class PrinterDropdown extends EventTarget {
    */
   #show(...elements) {
     elements.forEach((e) => {
-      e.classList.remove('invisible');
-      e.classList.add('visible');
+      e?.classList.remove('invisible');
+      e?.classList.add('visible');
     });
-  }
-
-  /**
-   * Gets the connect event name
-   */
-  static get ConnectEventName() {
-    return 'connect';
   }
 
   /**
@@ -226,6 +259,7 @@ export class PrinterDropdown extends EventTarget {
       testElement: doc.getElementById(`${prefix}PrintTest`),
       feedElement: doc.getElementById(`${prefix}PrintFeed`),
       configElement: doc.getElementById(`${prefix}PrintConfig`),
+      kitBadgeElement: doc.getElementById(`${prefix}PrintKit`),
     };
   }
 }

--- a/src/regdesk/printer_manager.js
+++ b/src/regdesk/printer_manager.js
@@ -1,6 +1,7 @@
 // This is used in doc comments..
 // eslint-disable-next-line no-unused-vars
 import { LabelEpl, LP2844 } from 'WebZLP/src/LP2844';
+import { BadgeLabelBuilder } from './label_builder.js';
 import { PrinterDropdown } from './printer_dropdown.js';
 
 /**
@@ -24,10 +25,17 @@ export class PrinterManager {
    */
   constructor(nav, adultDropdown, minorDropdown) {
     this.#adultDropdown = adultDropdown;
-    this.#adultDropdown.addEventListener(PrinterDropdown.ConnectEventName, async (e) => this.handleRequestConnect(e));
+    this.#adultDropdown.addEventListener(
+      PrinterDropdown.events.CONNECT_PRINTER,
+      async (e) => this.handleRequestConnect(e));
 
     this.#minorDropdown = minorDropdown;
-    this.#minorDropdown.addEventListener(PrinterDropdown.ConnectEventName, async (e) => this.handleRequestConnect(e));
+    this.#minorDropdown.addEventListener(
+      PrinterDropdown.events.CONNECT_PRINTER,
+      async (e) => this.handleRequestConnect(e));
+    this.#minorDropdown.addEventListener(
+      PrinterDropdown.events.PRINT_KIT_BADGE,
+      () => this.printKitBadge());
 
     // Convenience array
     this.#dropdowns = [this.#adultDropdown, this.#minorDropdown];
@@ -167,11 +175,11 @@ export class PrinterManager {
       return;
     }
 
-    await this.#adultDropdown.printer.printLabel(label);
+    await this.#adultDropdown.printLabel(label);
   }
 
   /**
-   * Get a lael for the minor printer.
+   * Get a label for the minor printer.
    * @return {LabelEpl} - The label, or {undefined} if the printer isn't connected.
    */
   getMinorLabel() {
@@ -195,7 +203,7 @@ export class PrinterManager {
       return;
     }
 
-    await this.#minorDropdown.printer.printLabel(label);
+    await this.#minorDropdown.printLabel(label);
   }
 
   /**
@@ -223,6 +231,22 @@ export class PrinterManager {
     } else {
       return this.printAdultLabel(label);
     }
+  }
+
+  /**
+   * Print a KIT badge
+   * @return {Promise} - The promise to complete when done printing.
+   */
+  async printKitBadge() {
+    const labelBuilder = new BadgeLabelBuilder({
+      line1: 'KID IN TOW',
+      line2: 'KIT',
+      badgeId: '',
+      level: '',
+      isMinor: true,
+    });
+
+    return this.printLabelBuilder(labelBuilder);
   }
 
   /**


### PR DESCRIPTION
Adds a static button to the minor print dropdown that just spits out a KIT badge.

![image](https://user-images.githubusercontent.com/1441553/147904811-25beb7ab-de71-4161-b73d-6f3e18d15ee1.png)

These badges contain static information, so just having an always-accessible button that is only available when the Minor printer is attached seemed like the logical option. The option isn't present on the Adult printer dropdown and is hidden if the minor printer isn't connected.

![image](https://user-images.githubusercontent.com/1441553/147904851-186b9ee4-e57a-4519-8064-0af2ffcfbfe4.png)
