### PR TITLE
Add manual label print button

### DIFF
--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -42,6 +42,8 @@
                 <span id="adultPrintIcon">❌</span> Adult <span id="adultPrintName">(No Printer)</span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <li id="adultPrintManual"><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#manualPrintModal">Manual Label</a></li>
+                <li><hr class="dropdown-divider"/></li>
                 <li id="adultPrintConnect"><a class="dropdown-item" href="#">Connect</a></li>
                 <li id="adultPrintDisconnect"><a class="dropdown-item" href="#">Disconnect</a></li>
                 <li id="adultPrintTest"><a class="dropdown-item" href="#">Print Test Page</a></li>
@@ -192,6 +194,50 @@
       </div>
       <div class="col-2 d-grid gap-2 h-100 container-no-gutter-right">
         <button id="printBtn" class="btn btn-success btn-fullheight btn-huge invisible">PRINT</button>
+      </div>
+    </div>
+  </div>
+  <div id="manualPrintModal" class="modal fade" tabindex="-1" aria-labelledby="manualPrintModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="manualPrintModalTitle">Manual Badge Print</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <form id="manualPrintModalForm" class="row">
+            <div class="mb-3 col-md-4">
+              <label for="manualPrintLine1" class="col-form-label">Line 1 (20 characters)</label>
+              <input type="text" class="form-control" id="manualPrintLine1" maxlength="20" />
+            </div>
+            <div class="mb-3 col-md-8">
+              <label for="manualPrintLine2" class="col-form-label">Line 2 (40 characters)</label>
+              <input type="text" class="form-control" id="manualPrintLine2" maxlength="40" />
+            </div>
+            <div class="mb-3 col-md-3">
+              <label for="manualPrintBadgeNumber" class="col-form-label">Badge ID (8 numbers)</label>
+              <input type="text" class="form-control" id="manualPrintBadgeNumber" maxlength="8" />
+            </div>
+            <div class="mb-3 col-md-5">
+              <label for="manualPrintLevel" class="col-form-label">Sponsor Level (15 characters, allcaps)</label>
+              <input type="text" class="form-control" id="manualPrintLevel" maxlength="15" />
+            </div>
+            <div class="mb-3 col-md-2">
+              <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="manualPrintIsMinor">
+                <label class="form-check-label" for="manualPrintIsMinor">Minor</label>
+              </div>
+            </div>
+            <div class="mb-3 col-md-12">
+              <label class="form-label">Badge Preview</label>
+              <canvas id="manualPrintBadgePreview" class="form-control badge-canvas" id="canvas" width="589" height="193"></canvas>
+            </div>
+          </form>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+          <button id="manualPrintModalBtn" type="button" class="btn btn-primary">🖨 Print</button>
+        </div>
       </div>
     </div>
   </div>

--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -42,7 +42,7 @@
                 <span id="adultPrintIcon">❌</span> Adult <span id="adultPrintName">(No Printer)</span>
               </a>
               <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <li id="adultPrintManual"><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#manualPrintModal">Manual Label</a></li>
+                <li id="adultPrintManual"><a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#manualPrintModal">Make Manual Label</a></li>
                 <li><hr class="dropdown-divider"/></li>
                 <li id="adultPrintConnect"><a class="dropdown-item" href="#">Connect</a></li>
                 <li id="adultPrintDisconnect"><a class="dropdown-item" href="#">Disconnect</a></li>

--- a/src/regdesk/manual_print_modal.js
+++ b/src/regdesk/manual_print_modal.js
@@ -1,0 +1,85 @@
+import { BadgeLabelBuilder } from './label_builder.js';
+
+/**
+ * Manaages the manual print modal dialog.
+ */
+export class ManualPrintModal extends EventTarget {
+  /**
+   * Get the events this class supports
+   */
+  static get events() {
+    return {
+      PRINT_LABEL: 'PRINT_LABEL',
+    };
+  }
+
+  #modalPrintForm;
+  #modalBadgePreview;
+
+  /**
+   * Initializes a new instance of the ManualPrintModal class.
+   * @param {Element} modalPrintBtn - The print button on the modal popup.
+   * @param {Element} modalPrintForm - The form element for the badge form.
+   * @param {HTMLCanvasElement} modalBadgePreview - The badge preview canvas.
+   */
+  constructor(modalPrintBtn, modalPrintForm, modalBadgePreview) {
+    super();
+
+    this.#modalPrintForm = modalPrintForm;
+    this.#modalBadgePreview = modalBadgePreview;
+
+    this.#modalPrintForm.addEventListener('change', this.updateBadgePreview.bind(this));
+    this.#modalPrintForm.querySelectorAll('input[type=text]')
+      .forEach((e) => e.addEventListener('keyup', this.updateBadgePreview.bind(this)));
+    modalPrintBtn.addEventListener('click', this.printForm.bind(this));
+  }
+
+  /**
+   * Update the bage preview based on the current form data.
+   */
+  updateBadgePreview() {
+    const label = this.getLabelBuilderFromForm();
+    const canvas = this.#modalBadgePreview;
+    const ctx = canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    label.renderToImageData(canvas.width, canvas.height, canvas);
+  }
+
+  /**
+   * Get a BadgeLabelBuilder from the form.
+   * @return {BadgeLabelBuilder} - The badge label builder based on the form state.
+   */
+  getLabelBuilderFromForm() {
+    const form = this.#modalPrintForm;
+    return new BadgeLabelBuilder({
+      line1: form.querySelector('#manualPrintLine1').value,
+      line2: form.querySelector('#manualPrintLine2').value,
+      badgeId: form.querySelector('#manualPrintBadgeNumber').value,
+      level: form.querySelector('#manualPrintLevel').value,
+      isMinor: form.querySelector('#manualPrintIsMinor').checked,
+    });
+  }
+
+  /**
+   * Print the form to a label based on the current form.
+   */
+  printForm() {
+    const label = this.getLabelBuilderFromForm();
+    this.dispatchEvent(new CustomEvent(
+      this.constructor.events.PRINT_LABEL,
+      { detail: label }));
+  }
+
+  /**
+   * Get a ManualPrintModal from the Document element.
+   * @param {Document} doc - The document element to find the elements on the page.
+   * @return {ManualPrintModal} - Ready to go manual print modal.
+   */
+  static getFromDocument(doc) {
+    return new ManualPrintModal(
+      doc.getElementById('manualPrintModalBtn'),
+      doc.getElementById('manualPrintModalForm'),
+      doc.getElementById('manualPrintBadgePreview'),
+    );
+  }
+}

--- a/src/regdesk/regdesk.js
+++ b/src/regdesk/regdesk.js
@@ -8,6 +8,7 @@ import 'bootstrap-dark-5/dist/css/bootstrap-dark-plugin.min.css';
 import { RegMachineArgs } from './states/reg_machine_args.js';
 import { RegMachineManager } from './states/reg_machine_manager.js';
 import { CommunicationManager } from './communication_manager.js';
+import { ManualPrintModal } from './manual_print_modal.js';
 
 /**
  * Configure the printer manager for this page
@@ -39,6 +40,11 @@ document.addEventListener('readystatechange', async () => {
     printerMgr = configureManager();
     await printerMgr.refreshPrinters();
     await fontLoader;
+
+    const printModal = ManualPrintModal.getFromDocument(document);
+    printModal.addEventListener(ManualPrintModal.events.PRINT_LABEL, (e) => {
+      printerMgr.printLabelBuilder(e.detail);
+    });
 
     const commMgr = new CommunicationManager();
 


### PR DESCRIPTION
Adds an interface for manually entering arbitrary badge details.

I'm sure this won't be used to generate hilarious badges.

![image](https://user-images.githubusercontent.com/1441553/147909721-f4e6ca48-182d-448d-8007-49f637263641.png)

Interface is similar to the KIT badge, click the Adult printer dropdown and it's there. 

![image](https://user-images.githubusercontent.com/1441553/147909767-37ef7ee7-5fc4-4ebe-abc7-d2c36d27a2d7.png)
