### PR TITLE
Add printer config modal

### DIFF
--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -240,9 +240,9 @@
                 </div>
               </div>
               <div class="col-md-4">
-                <label for="printerSettingsDarkness" class="col-sm-6 col-form-label">Darkness</label>
+                <label for="printerSettingsDarkness" class="form-label">Print Darkness</label>
                 <select id="printerSettingsDarkness" class="form-select" aria-label="Darkness">
-                  <option>1</option>
+                  <option value="1">1 - Lightest</option>
                   <option>2</option>
                   <option>3</option>
                   <option>4</option>
@@ -256,16 +256,16 @@
                   <option>12</option>
                   <option>13</option>
                   <option>14</option>
-                  <option>15</option>
+                  <option value="15">15 -Darkest</option>
                 </select>
               </div>
               <div class="col-md-4">
-                <label for="printerSettingsSpeed" class="col-sm-5 col-form-label">Speed</label>
+                <label for="printerSettingsSpeed" class="form-label">Print Speed</label>
                 <select id="printerSettingsSpeed" class="form-select" aria-label="Speed">
-                  <option>1</option>
-                  <option>2</option>
-                  <option>3</option>
-                  <option>4</option>
+                  <option value="1">1.5ips</option>
+                  <option value="2">2.0ips</option>
+                  <option value="3">2.5ips</option>
+                  <option value="4">3.5ips</option>
                 </select>
               </div>
             </div>

--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -197,6 +197,74 @@
       </div>
     </div>
   </div>
+  <div id="printerOptionModal" class="modal" tabindex="-1">
+      <div class="modal-dialog">
+          <div class="modal-content">
+              <form id="printerSettingsForm">
+                  <div class="modal-header">
+                    <h5 class="modal-title">Printer Settings For: <span id="printerSettingsSerial"></span></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                  </div>
+                  <div class="modal-body">
+                    <div class="row">
+                      <div class="col-md-12 alert alert-danger">
+                        Do not change the configuration when the label dispenser is engaged. It will dispense many labels and not stop. Ensure dispenser is disengaged before saving.
+                      </div>
+                      <div class="col-md-6">
+                        <label for="printerSettingsLabelWidth" class="form-label">Label Width</label>
+                        <div class="input-group mb-3">
+                            <input id="printerSettingsLabelWidth" type="text" class="form-control" placeholder="2.25"
+                                aria-label="Width" required pattern="\d+\.*\d*">
+                            <span class="input-group-text">in</span>
+                        </div>
+                      </div>
+                      <div class="col-md-6">
+                        <label for="printerSettingsLabelHeight" class="form-label">Label Height</label>
+                        <div class="input-group mb-3">
+                            <input id="printerSettingsLabelHeight" type="text" class="form-control" placeholder="1.25"
+                                aria-label="Height" required pattern="\d+\.*\d*">
+                            <span class="input-group-text">in</span>
+                        </div>
+                      </div>
+                      <div class="col-md-4">
+                        <label for="printerSettingsDarkness" class="col-sm-6 col-form-label">Darkness</label>
+                        <select id="printerSettingsDarkness" class="form-select" aria-label="Darkness">
+                            <option>1</option>
+                            <option>2</option>
+                            <option>3</option>
+                            <option>4</option>
+                            <option>5</option>
+                            <option>6</option>
+                            <option>7</option>
+                            <option>8</option>
+                            <option>9</option>
+                            <option>10</option>
+                            <option>11</option>
+                            <option>12</option>
+                            <option>13</option>
+                            <option>14</option>
+                            <option>15</option>
+                        </select>
+                      </div>
+                      <div class="col-md-4">
+                        <label for="printerSettingsSpeed" class="col-sm-5 col-form-label">Speed</label>
+                        <select id="printerSettingsSpeed" class="form-select" aria-label="Speed">
+                            <option>1</option>
+                            <option>2</option>
+                            <option>3</option>
+                            <option>4</option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <input type="submit" class="btn btn-primary" value="Save">
+                  </div>
+              </form>
+          </div>
+      </div>
+  </div>
   <script src="regdesk.js"></script>
 </body>
 

--- a/src/regdesk/printer_config_modal.js
+++ b/src/regdesk/printer_config_modal.js
@@ -1,0 +1,64 @@
+// eslint-disable-next-line no-unused-vars
+import { LP2844 } from 'webzlp/src/LP2844';
+import { Modal } from 'bootstrap';
+
+/**
+ * Manages the printer configuration modal
+ */
+export class PrinterConfigModal {
+  /**
+   * Initializes a new instance of the PrinterConfigModal class.
+   * @param {Element} printerModal - The modal dialog for configuring the printer.
+   */
+  constructor(printerModal) {
+    this.modal = new Modal(printerModal);
+    this.form = printerModal.querySelector('form');
+    this.printerSerial = this.form.querySelector('#printerSettingsSerial');
+    this.printerLabelWidth = this.form.querySelector('#printerSettingsLabelWidth');
+    this.printerLabelHeight = this.form.querySelector('#printerSettingsLabelHeight');
+    this.printerDarkness = this.form.querySelector('#printerSettingsDarkness');
+    this.printerSpeed = this.form.querySelector('#printerSettingsSpeed');
+
+    this.form.addEventListener('submit', this.#updatePrinterConfig.bind(this));
+
+    this.printer;
+  }
+
+  /**
+   * Open the printer configuration page.
+   * @param {LP2844} printer - The printer to configure.
+   */
+  open(printer) {
+    if (!printer) {
+      console.error('Printer argument to config modal was not a printer.');
+      return;
+    }
+
+    this.printer = printer;
+
+    this.printerSerial.textContent = printer.serial;
+    this.printerLabelWidth.value = printer.labelWidth;
+    this.printerLabelHeight.value = printer.labelHeight;
+    this.printerDarkness.value = printer.density;
+    this.printerSpeed.value = printer.speed;
+
+    this.modal.show();
+  }
+
+  /**
+   * Update the printer configuration.
+   * @param {CustomEvent} e - The event object
+   */
+  async #updatePrinterConfig(e) {
+    e.preventDefault();
+    this.modal.hide();
+
+    this.printer.labelWidth = (parseFloat(this.printerLabelWidth.value));
+    this.printer.labelHeight = (parseFloat(this.printerLabelHeight.value));
+    await this.printer.configDensity(this.printerDarkness.value);
+    await this.printer.configSpeed(this.printerSpeed.value);
+    await this.printer.configPrintDirection();
+    await this.printer.configLabelWidth();
+    await this.printer.setLabelHeightCalibration();
+  }
+}

--- a/src/regdesk/printer_dropdown.js
+++ b/src/regdesk/printer_dropdown.js
@@ -14,6 +14,7 @@ export class PrinterDropdown extends EventTarget {
     return {
       CONNECT_PRINTER: 'CONNECT_PRINTER',
       PRINT_KIT_BADGE: 'PRINT_KIT_BADGE',
+      CONFIGURE_PRINTER: 'CONFIGURE_PRINTER',
     };
   }
   /**
@@ -98,7 +99,7 @@ export class PrinterDropdown extends EventTarget {
     this.#feedPrintElement.addEventListener('click', () => this.feedLabel());
 
     this.#configElement = configElement;
-    this.#connectElement.addEventListener('click', () => this.showConfig());
+    this.#configElement.addEventListener('click', this.#showConfig.bind(this));
 
     this.#kitBadgeElement = kitBadgeElement;
     this.#kitBadgeElement?.addEventListener('click', () => this.#printKitBadge());
@@ -121,6 +122,21 @@ export class PrinterDropdown extends EventTarget {
    */
   #printKitBadge() {
     const event = new CustomEvent(this.constructor.events.PRINT_KIT_BADGE);
+    this.dispatchEvent(event);
+  }
+
+  /**
+   * Show the configuration for this printer.
+   */
+  #showConfig() {
+    if (!this.#printer) {
+      console.error('No printer selected, can\'t configure.');
+      return;
+    }
+
+    const event = new CustomEvent(
+      this.constructor.events.CONFIGURE_PRINTER,
+      { detail: this.#printer });
     this.dispatchEvent(event);
   }
 
@@ -179,6 +195,7 @@ export class PrinterDropdown extends EventTarget {
   async printLabel(label) {
     if (!this.#printer) {
       console.error('No printer selected, can\'t print test page.');
+      return Promise.resolve();
     }
 
     return this.#printer.printLabel(label);
@@ -190,6 +207,7 @@ export class PrinterDropdown extends EventTarget {
   async printTest() {
     if (!this.#printer) {
       console.error('No printer selected, can\'t print test page.');
+      return Promise.resolve();
     }
 
     try {
@@ -205,6 +223,7 @@ export class PrinterDropdown extends EventTarget {
   async feedLabel() {
     if (!this.#printer) {
       console.error('No printer selected, can\'t feed a label.');
+      return Promise.resolve();
     }
 
     try {
@@ -212,13 +231,6 @@ export class PrinterDropdown extends EventTarget {
     } catch (error) {
       console.error('Failed to feed label.', error);
     }
-  }
-
-  /**
-   * Show the configuration for this printer.
-   */
-  showConfig() {
-    // idk figure out how to show the modal with the printer config.
   }
 
   /**

--- a/src/regdesk/printer_manager.js
+++ b/src/regdesk/printer_manager.js
@@ -2,6 +2,8 @@
 // eslint-disable-next-line no-unused-vars
 import { LabelEpl, LP2844 } from 'WebZLP/src/LP2844';
 import { BadgeLabelBuilder } from './label_builder.js';
+// eslint-disable-next-line no-unused-vars
+import { PrinterConfigModal } from './printer_config_modal.js';
 import { PrinterDropdown } from './printer_dropdown.js';
 
 /**
@@ -11,6 +13,8 @@ export class PrinterManager {
   #adultDropdown;
   #minorDropdown;
   #dropdowns;
+
+  #printerConfigModal;
 
   #printerType = LP2844;
 
@@ -22,20 +26,31 @@ export class PrinterManager {
    * @param {Navigator} nav - Browser Navigator to hook up events to.
    * @param {PrinterDropdown} adultDropdown - The dropdown object managing the adult printer.
    * @param {PrinterDropdown} minorDropdown - The dropdown object managing the Minor printer.
+   * @param {PrinterConfigModal} printerConfigModal - The printer configuration modal.
    */
-  constructor(nav, adultDropdown, minorDropdown) {
+  constructor(nav, adultDropdown, minorDropdown, printerConfigModal) {
+    this.#printerConfigModal = printerConfigModal;
+
     this.#adultDropdown = adultDropdown;
     this.#adultDropdown.addEventListener(
       PrinterDropdown.events.CONNECT_PRINTER,
-      async (e) => this.handleRequestConnect(e));
+      this.handleRequestConnect.bind(this));
+    this.#adultDropdown.addEventListener(
+      PrinterDropdown.events.CONFIGURE_PRINTER,
+      this.handleConfigurePrinter.bind(this),
+    );
 
     this.#minorDropdown = minorDropdown;
     this.#minorDropdown.addEventListener(
       PrinterDropdown.events.CONNECT_PRINTER,
-      async (e) => this.handleRequestConnect(e));
+      this.handleRequestConnect.bind(this));
+    this.#minorDropdown.addEventListener(
+      PrinterDropdown.events.CONFIGURE_PRINTER,
+      this.handleConfigurePrinter.bind(this),
+    );
     this.#minorDropdown.addEventListener(
       PrinterDropdown.events.PRINT_KIT_BADGE,
-      () => this.printKitBadge());
+      this.printKitBadge.bind(this));
 
     // Convenience array
     this.#dropdowns = [this.#adultDropdown, this.#minorDropdown];
@@ -106,6 +121,14 @@ export class PrinterManager {
     }
 
     return printer;
+  }
+
+  /**
+   * Handle a request to configure a printer
+   * @param {CustomEvent} e - The event object
+   */
+  handleConfigurePrinter(e) {
+    this.#printerConfigModal.open(e.detail);
   }
 
   /**

--- a/src/regdesk/regdesk.js
+++ b/src/regdesk/regdesk.js
@@ -8,6 +8,7 @@ import 'bootstrap-dark-5/dist/css/bootstrap-dark-plugin.min.css';
 import { RegMachineArgs } from './states/reg_machine_args.js';
 import { RegMachineManager } from './states/reg_machine_manager.js';
 import { CommunicationManager } from './communication_manager.js';
+import { PrinterConfigModal } from './printer_config_modal.js';
 
 /**
  * Configure the printer manager for this page
@@ -17,6 +18,7 @@ import { CommunicationManager } from './communication_manager.js';
  * @param {PrinterDropdown} o.adultDropdown - The dropdown object managing the Clear printer.
  * @param {PrinterDropdown} o.minorDropdown - The dropdown object managing the Minor printer.
  * @param {Navigator} o.nav - The browser Navigator.
+ * @param {PrinterConfigModal} o.configModal - The printer configuration modal.
  * @return {PrinterManager} - The resulting printer manager.
  */
 function configureManager({
@@ -24,8 +26,9 @@ function configureManager({
   adultDropdown = new PrinterDropdown(PrinterDropdown.getElementsOnPage('adult', document)),
   minorDropdown = new PrinterDropdown(PrinterDropdown.getElementsOnPage('minor', document)),
   nav = navigator,
+  configModal = new PrinterConfigModal(document.getElementById('printerOptionModal')),
 } = {}) {
-  mgr = mgr || new PrinterManager(nav, adultDropdown, minorDropdown);
+  mgr = mgr || new PrinterManager(nav, adultDropdown, minorDropdown, configModal);
   return mgr;
 }
 


### PR DESCRIPTION
Adds a modal dialog for configuring printer details. The printer config is limited to relevant config items that might need to be changed or validated at the con. 

This wires the previously added config buttons that weren't doing anything.

![image](https://user-images.githubusercontent.com/1441553/148000343-f5ec98f5-95c5-4d0d-b1b5-1796cb7e546d.png)
