### PR TITLE
Add toggle payments button to regfox comm dropdown

### DIFF
--- a/public/regdesk.html
+++ b/public/regdesk.html
@@ -16,10 +16,23 @@
   <div class="container-fluid container-no-gutter-left container-no-gutter-right container-fullheight-with-navbar">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid container-no-gutter d-flex">
-        <span class="navbar-brand me-auto" href="#">
-          <span id="regfoxStatusIcon">✔</span>
-          Connected
-        </span>
+        <div class="navbar-nav nav-item dropdown">
+          <a class="nav-link dropdown-toggle active" href="#" id="connectConfig" role="button"
+            data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+            <span id="regfoxStatusIcon">✔</span> RegFox Status: <span id="regfoxsTatusText">Connected</span>
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="connectConfig">
+            <li>
+              <button id="togglePaymentsBtn" class="btn btn-outline-warning me-2" type="button">
+                <div class="form-check form-switch">
+                  <input class="form-check-input" type="checkbox" id="togglePaymentsSwitch">
+                  <label class="form-check-label pmt-allowed d-none" for="togglePaymentsSwitch">Payments allowed</label>
+                  <label class="form-check-label pmt-denied" for="togglePaymentsSwitch">Payments denied</label>
+                </div>
+              </button>
+            </li>
+          </ul>
+        </div>
         <div>
           <ul class="navbar-nav">
             <li class="nav-item dropdown">

--- a/src/regdesk/communication_manager.js
+++ b/src/regdesk/communication_manager.js
@@ -1,14 +1,29 @@
+import { TogglePaymentsBtn } from './toggle_payments_btn.js';
 
 /**
  * Manager for handling communication to the extension and APIs.
  */
 export class CommunicationManager {
+  #acceptingPayments;
+  #togglePaymentsBtn;
+
+  /**
+   * Indicates whether this terminal is accepting payments.
+   */
+  get acceptingPayments() {
+    return this.#acceptingPayments;
+  }
+
   /**
    * Iniitalizes a new instance of the CommunicationManager class.
+   * @param {TogglePaymentsBtn} togglePaymentsBtn - Button to toggle payment acceptance
    */
-  constructor() {
-    // TODO: Wire this up to a UI element
-    this.acceptingPayments = true;
+  constructor(togglePaymentsBtn) {
+    this.#acceptingPayments = false;
+    this.#togglePaymentsBtn = togglePaymentsBtn;
+    this.#togglePaymentsBtn.addEventListener(
+      TogglePaymentsBtn.events.TOGGLE_PAYMENTS,
+      this.#togglePayments.bind(this));
   }
 
   /**
@@ -56,6 +71,14 @@ export class CommunicationManager {
     // TODO: Assumes an array, who knows what we get back from the API though.
     // TODO: Whatever massaging necessary from the real API.
     return results;
+  }
+
+  /**
+   * Toggle the state of accepting payments.
+   * @param {CustomEvent} e - The event object
+   */
+  #togglePayments(e) {
+    this.#acceptingPayments = e.detail.acceptingPayments;
   }
 
   /**

--- a/src/regdesk/regdesk.js
+++ b/src/regdesk/regdesk.js
@@ -10,6 +10,7 @@ import { RegMachineManager } from './states/reg_machine_manager.js';
 import { CommunicationManager } from './communication_manager.js';
 import { PrinterConfigModal } from './printer_config_modal.js';
 import { ManualPrintModal } from './manual_print_modal.js';
+import { TogglePaymentsBtn } from './toggle_payments_btn.js';
 
 /**
  * Configure the printer manager for this page
@@ -49,7 +50,8 @@ document.addEventListener('readystatechange', async () => {
       printerMgr.printLabelBuilder(e.detail);
     });
 
-    const commMgr = new CommunicationManager();
+    const togglePaymentsBtn = new TogglePaymentsBtn(document.getElementById('togglePaymentsBtn'));
+    const commMgr = new CommunicationManager(togglePaymentsBtn);
 
     const stateArgs = RegMachineArgs.getFromDocument(document, printerMgr, commMgr);
 

--- a/src/regdesk/toggle_payments_btn.js
+++ b/src/regdesk/toggle_payments_btn.js
@@ -1,0 +1,66 @@
+
+/**
+ * Manages the toggle payments display button.
+ */
+export class TogglePaymentsBtn extends EventTarget {
+  /**
+   * Get the events this object can generate.
+   */
+  static get events() {
+    return {
+      TOGGLE_PAYMENTS: 'TOGGLE_PAYMENTS',
+    };
+  }
+
+  #acceptingPayments;
+  #togglePaymentsBtn;
+  #togglePaymentsSwitch;
+  #togglePaymentsLabelAllowed;
+  #togglePaymentsLabelDenied;
+
+  /**
+   * Initializes a new instance of the TogglePaymentsBtn class.
+   * @param {Element} togglePaymentsBtn - The button to toggle payments
+   */
+  constructor(togglePaymentsBtn) {
+    super();
+
+    this.#togglePaymentsBtn = togglePaymentsBtn;
+    this.#togglePaymentsSwitch = togglePaymentsBtn.querySelector('input');
+    this.#togglePaymentsLabelAllowed = togglePaymentsBtn.querySelector('label.pmt-allowed');
+    this.#togglePaymentsLabelDenied = togglePaymentsBtn.querySelector('label.pmt-denied');
+    this.#togglePaymentsBtn.addEventListener('click', this.handleTogglePayments.bind(this));
+
+    // Start with accepting payments to true, then toggle it off to set the UI elements.
+    this.#acceptingPayments = true;
+    this.handleTogglePayments();
+  }
+
+  /**
+   * Handle the toggle event from the button.
+   * @param {Event} e - The event object.
+   */
+  handleTogglePayments(e) {
+    e?.preventDefault();
+
+    const accepting = !this.#acceptingPayments;
+    this.#acceptingPayments = accepting;
+    this.#togglePaymentsSwitch.checked = accepting;
+
+    if (accepting) {
+      this.#togglePaymentsBtn.classList.remove('btn-outline-warning');
+      this.#togglePaymentsBtn.classList.add('btn-success');
+      this.#togglePaymentsLabelAllowed.classList.remove('d-none');
+      this.#togglePaymentsLabelDenied.classList.add('d-none');
+    } else {
+      this.#togglePaymentsBtn.classList.remove('btn-success');
+      this.#togglePaymentsBtn.classList.add('btn-outline-warning');
+      this.#togglePaymentsLabelDenied.classList.remove('d-none');
+      this.#togglePaymentsLabelAllowed.classList.add('d-none');
+    }
+
+    this.dispatchEvent(new CustomEvent(
+      this.constructor.events.TOGGLE_PAYMENTS,
+      { detail: { acceptingPayments: accepting } }));
+  }
+}


### PR DESCRIPTION
This turns the top-left element into a dropdown so we can add communication relevant options. My first mockup had this button straight up on the navbar, but in considering it I think that's _too_ easy to find and use. Eschewing the payment enable toggle behind another dropdown makes it much more difficult to hit accidentally.

In the same way that the buttons in the top right are the purview of the Printer Manager, the button in the top left is the purview of the Communication Manager, and any comms-related things (like a button to re-log-into RegFox or something) should go there.

The toggle itself is very clearly off when off, and very clearly on when on.

![F0Q0Z28zrg](https://user-images.githubusercontent.com/1441553/148026954-c662e73d-7605-47c3-b2ee-6782533dff56.gif)

