### PR TITLE
Set label alignment tweaks, make printers happy

### DIFF
--- a/src/regdesk/label_builder.js
+++ b/src/regdesk/label_builder.js
@@ -74,7 +74,7 @@ export class BadgeLabelBuilder {
       // Manually calculated offsets to figure out a good mapping for a label
       // with a width of 589px and height of 193px.
       // These will absolutely need to be recalculated for other sizes.
-      'line1': new LineOffset('center', true, LineOffset.fullLabelWidth, 110, LineOffset.centeredOnLabel, 50),
+      'line1': new LineOffset('center', true, LineOffset.fullLabelWidth, 108, LineOffset.centeredOnLabel, 52),
       'line2': new LineOffset('center', true, LineOffset.fullLabelWidth, 53, LineOffset.centeredOnLabel, 130),
       'level': new LineOffset('center', false, 400, 40, LineOffset.centeredOnLabel, 175),
       'minor': new LineOffset('right', false, 95, 20, 585, 180),

--- a/src/regdesk/printer_config_modal.js
+++ b/src/regdesk/printer_config_modal.js
@@ -59,6 +59,7 @@ export class PrinterConfigModal {
     await this.printer.configSpeed(this.printerSpeed.value);
     await this.printer.configPrintDirection();
     await this.printer.configLabelWidth();
-    await this.printer.setLabelHeightCalibration();
+    // Sets the label length with a label gap of 25 dots.
+    await this.printer.addCmd(`Q${this.printer.labelHeightDots + 5},25`).print();
   }
 }

--- a/src/regdesk/printer_manager.js
+++ b/src/regdesk/printer_manager.js
@@ -1,6 +1,7 @@
 // This is used in doc comments..
 // eslint-disable-next-line no-unused-vars
-import { LabelEpl, LP2844 } from 'webzlp/src/LP2844';
+import { LabelEpl } from 'webzlp/src/LabelEpl';
+import { LP2844 } from 'webzlp/src/LP2844';
 import { BadgeLabelBuilder } from './label_builder.js';
 // eslint-disable-next-line no-unused-vars
 import { PrinterConfigModal } from './printer_config_modal.js';
@@ -247,7 +248,7 @@ export class PrinterManager {
     }
 
     const labelImage = builder.renderToImageSizedToLabel(label.labelWidthDots, label.labelHeightDots);
-    label.setOffset(labelImage.widthOffset).addImage(labelImage.canvasData);
+    label.setOffset(labelImage.widthOffset, 8).addImage(labelImage.canvasData);
 
     if (builder.isMinor) {
       return this.printMinorLabel(label);


### PR DESCRIPTION
These are just minor alignment tweaks to better ensure all of the printers act the same.

The background here is that each of these printers are exhibiting some.. drift with how precisely they're calculating label sizes and offsets. Two of them were off to the point where it was cutting off text.

These offsets should ensure they're all properly calibrated as of me testing literally all 12 tonight.