### PR TITLE
Add RegFox page print button

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -12,6 +12,7 @@ const config = (env, argv) => merge(common, {
     event_page: PATHS.src + '/event_page.js',
     popup: PATHS.src + '/popup.js',
     disable_auto_logout: PATHS.src + '/disable_auto_logout.js',
+    detail_print: PATHS.src + '/detail_print.js',
     regdesk: PATHS.src + '/regdesk/regdesk.js',
   },
   devtool: argv.mode === 'production' ? false : 'source-map',

--- a/src/coms/communication.js
+++ b/src/coms/communication.js
@@ -3,16 +3,20 @@ const MESSAGE_TYPE = {
   changeLogout: 'change-logout-plz', // payload is a boolean
   finishLoad: 'load-plz', // payload is the name of the script that just loaded
   printLegacy: 'print-legacy-plz', // payload is undefined
+  printLabel: 'print-label-plz', // payload is a BadgeLabelBuilder.
 };
 
 /**
- * Sends a message to the background script. Technically asynchronous, and technically the popup can listen in on these.
+ * Sends a message to the background script. Technically asynchronous, and
+ * technically the popup can listen in on these.
  *
  * @param {*} type one of MESSAGE_TYPES
  * @param {*} payload whatever object you want
+ * @param {function(*?)} callback - Optional response handler for a response from
+ * the message handler.
  */
-const sendBackgroundScriptAMessage = (type, payload) => {
-  chrome.runtime.sendMessage({ type, payload });
+const sendBackgroundScriptAMessage = (type, payload, callback) => {
+  chrome.runtime.sendMessage({ type, payload }, callback);
 };
 
 /**

--- a/src/detail_print.js
+++ b/src/detail_print.js
@@ -1,0 +1,113 @@
+console.debug('Injected detail print script');
+
+import { sendBackgroundScriptAMessage, MESSAGE_TYPE } from './coms/communication.js';
+
+/**
+ * Wait for an element to be present on the page.
+ * @param {string} selector - The CSS selector to wait for
+ * @return {Element} The element being waited for
+ */
+async function waitForElement(selector) {
+  let element = document.querySelector(selector);
+  while (!element) {
+    element = document.querySelector(selector);
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return element;
+}
+
+/**
+ * Returns a value indicating whether the payment is complete.
+ * @return {boolean} Whether payment is completed
+ */
+function isPaymentCompleted() {
+  const payStatus = document.querySelector('tr[ng-if*="report.statusString"] > td').textContent;
+  return payStatus === 'Completed';
+}
+
+/**
+ * Get the details for a reg data table entry.
+ * @param {string} fieldName - The text field name from the reg details table
+ * @return {string} The value of the table
+ */
+function getDetail(fieldName) {
+  const regDetailTable = document.querySelector('div[ng-include*="data.html"] > table');
+  const th = [...regDetailTable.querySelectorAll('th')]
+    .filter((el) => el.textContent.indexOf(fieldName) > -1);
+
+  if (th.length > 0) {
+    return th[0]?.nextElementSibling.textContent ?? '';
+  }
+  return '';
+}
+
+/**
+ * Get an age in years between the birthdate and today.
+ * @param {string} birthdate - The raw birthdate string, in YYYY-mm-dd format.
+ * @param {Date} today - The 'today' value to use. Defaults to new Date().
+ * @return {number} - Age in years between the birthdate and today.
+ */
+function getAge(birthdate, today = new Date()) {
+  // TODO: This method should move to a dedicated Registrant class.
+  const yearInMs = 3.15576e+10;
+  return Math.floor((today - new Date(birthdate).getTime()) / yearInMs);
+}
+
+/**
+ * Get the details for a badge.
+ * @return {*} The details to populate a BadgeLabelBuilder
+ */
+function getBadgeDetails() {
+  const dob = getDetail('Date of Birth');
+  const age = getAge(dob);
+  return {
+    line1: getDetail('Badge Line 1 Text'),
+    line2: getDetail('Badge Line 2 Text'),
+    level: getDetail('Membership Levels'),
+    badgeId: document.location.href.split('/').pop(),
+    isMinor: (age < 18),
+  };
+}
+
+/**
+ * Send a request to print a badge to the RegDesk page and printers.
+ */
+function printBadge() {
+  if (!isPaymentCompleted()) {
+    // Most reliable way to ask the user..
+    const bypassPayment = window.confirm('The payment status in not "Completed". Are you sure you want to print this badge?');
+    if (!bypassPayment) {
+      return;
+    }
+  }
+
+  const labelDetails = getBadgeDetails();
+  console.log(labelDetails);
+
+  sendBackgroundScriptAMessage(
+    MESSAGE_TYPE.printLabel,
+    { labelDetails: labelDetails },
+    (r) => {
+      if (!r.success) {
+        // Not great, but the most reliable way to pop up a dialog.
+        alert('There was an error printing the badge, see the RegDesk page for details.');
+      }
+    });
+}
+
+const buttonRowSelector = 'div.page-action.button-set';
+waitForElement(buttonRowSelector)
+  .then((buttonRow) => {
+    const printButton = document.createElement('a');
+    printButton.classList.add('btn');
+    printButton.href = '#';
+    printButton.textContent = 'Print Badge';
+
+    const printButtonIcon = document.createElement('i');
+    printButtonIcon.classList.add('fa', 'fa-print');
+    printButton.prepend(printButtonIcon);
+
+    printButton.addEventListener('click', printBadge);
+
+    buttonRow.prepend(printButton);
+  });

--- a/src/detail_print.js
+++ b/src/detail_print.js
@@ -8,8 +8,10 @@ import { sendBackgroundScriptAMessage, MESSAGE_TYPE } from './coms/communication
  * @return {Element} The element being waited for
  */
 async function waitForElement(selector) {
+  let failLimit = 40; // 40 = 8 seconds.
   let element = document.querySelector(selector);
-  while (!element) {
+  while (!element && failLimit > 0) {
+    failLimit--;
     element = document.querySelector(selector);
     await new Promise((r) => setTimeout(r, 200));
   }

--- a/src/event_page.js
+++ b/src/event_page.js
@@ -18,7 +18,7 @@ const getAllRegfoxTabs = async () => {
 
 const injectPrintButtonScript = (tabId, change) => {
   // Change event only includes the details that actaully changed. We only want
-  // to inject this script
+  // to inject this script on the right page.
   if (!change?.url?.match(/manage\.webconnex\.com\/a\/\d+\/reports\/orders\/\d+\/details/)) {
     return;
   }

--- a/src/event_page.js
+++ b/src/event_page.js
@@ -16,7 +16,22 @@ const getAllRegfoxTabs = async () => {
   return chrome.tabs.query(queryOptions);
 };
 
+const injectPrintButtonScript = (tabId, change) => {
+  // Change event only includes the details that actaully changed. We only want
+  // to inject this script
+  if (!change?.url?.match(/manage\.webconnex\.com\/a\/\d+\/reports\/orders\/\d+\/details/)) {
+    return;
+  }
+
+  chrome.scripting.executeScript({
+    target: { tabId: tabId },
+    files: ['detail_print.js'],
+  });
+};
+
 const init = () => {
+  chrome.tabs.onUpdated.addListener(injectPrintButtonScript);
+
   chrome.runtime.onMessage.addListener(async (request, sender, sendResponse) => {
     if (request.type === MESSAGE_TYPE.printLegacy) {
       // TODO, should probably just use content scripts?

--- a/src/regdesk/regdesk.js
+++ b/src/regdesk/regdesk.js
@@ -51,7 +51,7 @@ document.addEventListener('readystatechange', async () => {
     });
 
     const togglePaymentsBtn = new TogglePaymentsBtn(document.getElementById('togglePaymentsBtn'));
-    const commMgr = new CommunicationManager(togglePaymentsBtn);
+    const commMgr = new CommunicationManager(printerMgr, togglePaymentsBtn);
 
     const stateArgs = RegMachineArgs.getFromDocument(document, printerMgr, commMgr);
 


### PR DESCRIPTION
This adds a button directly in the RegFox UI to print a badge label for a registrant.

![image](https://user-images.githubusercontent.com/1441553/148200463-e9ceca42-ae20-4d9b-9dc6-a953ce7bbf64.png)

This is not tested for _multiple_ registrants in a single transaction, that'll happen tomorrow.

The underlying framework for this is passing a message from a content script over to the RegDesk, this means we expect to have both RegFox and RegDesk open in two tabs on any cashier machine. 