### PR TITLE
Add checkIn regfox api.

### DIFF
--- a/test/mocks/mws_handler.js
+++ b/test/mocks/mws_handler.js
@@ -1,5 +1,5 @@
 import { graphql, rest } from 'msw';
-import { TEST_REGFOX_GRAPHQL_URL, TEST_REGFOX_EXCHANGE_TOKEN_URL, testGetRegistrationInfoUrl, testGetMarkRegistrationCompleteUrl, TEST_REGFOX_ADD_NOTE_URL } from '../../src/regfox/regfox_api.js';
+import { TEST_REGFOX_GRAPHQL_URL, TEST_REGFOX_EXCHANGE_TOKEN_URL, testGetRegistrationInfoUrl, testGetMarkRegistrationCompleteUrl, TEST_REGFOX_ADD_NOTE_URL, testGetCheckInUrl } from '../../src/regfox/regfox_api.js';
 
 const regfox = graphql.link(TEST_REGFOX_GRAPHQL_URL);
 
@@ -63,4 +63,18 @@ const addNoteHandler = (getResponse) => {
   ];
 };
 
-export { getRegistrantsSearchHandler, exchangeBearerTokenHandler, loginHandler, getRegistrationInfoHandler, markRegistrationCompleteHandler, addNoteHandler };
+const checkInHandler = (id, getResponse) => {
+  return [
+    rest.post(testGetCheckInUrl(id), (req, res, ctx) => {
+      const response = getResponse(req);
+      const resObj = response ? ctx.json(response) : ctx.status(200);
+
+      return res(resObj);
+    }),
+  ];
+};
+
+export {
+  getRegistrantsSearchHandler, exchangeBearerTokenHandler, loginHandler,
+  getRegistrationInfoHandler, markRegistrationCompleteHandler, addNoteHandler, checkInHandler
+};

--- a/test/mocks/mws_handler.js
+++ b/test/mocks/mws_handler.js
@@ -76,5 +76,5 @@ const checkInHandler = (id, getResponse) => {
 
 export {
   getRegistrantsSearchHandler, exchangeBearerTokenHandler, loginHandler,
-  getRegistrationInfoHandler, markRegistrationCompleteHandler, addNoteHandler, checkInHandler
+  getRegistrationInfoHandler, markRegistrationCompleteHandler, addNoteHandler, checkInHandler,
 };

--- a/test/regfox/regfox_api.integration.js
+++ b/test/regfox/regfox_api.integration.js
@@ -7,7 +7,7 @@ use(chaiAsPromised);
 should();
 const { expect } = chai;
 
-import { searchRegistrations, login, getRegistrationInfo, markRegistrationComplete, addNote } from '../../src/regfox/regfox_api.js';
+import { searchRegistrations, login, getRegistrationInfo, markRegistrationComplete, addNote, checkIn } from '../../src/regfox/regfox_api.js';
 
 const loginForTest = async () => {
   const email = process.env.EMAIL;
@@ -134,5 +134,15 @@ describe('regfox_api (integration testing)', () => {
       expect(registrantInfoWithNote.notes).to.have.lengthOf(registrantInfo.notes.length + 1);
       expect(some(registrantInfoWithNote.notes, { message })).to.be.true;
     }).timeout(50000);
+
+    it.allowFail('successfully checks in a registrant', async function () {
+      assert.exists(bearerToken);
+      const results = await searchRegistrations(TEST_NAME, bearerToken);
+      const registrant = findTestRegistrant(results);
+
+      const result = await checkIn(registrant.id, bearerToken);
+
+      expect(result).to.deep.equal({ 'status': 'OK' });
+    });
   });
 });


### PR DESCRIPTION
I saw the official API here and started that implementation, 

https://docs.webconnex.io/api/v2/#check-in-by-id

But right at the end noticed it takes in an API key rather than a bearer token. After much internal debate, I decided consistency was more important at the moment. So I'm using the front-end API instead. 