### PR TITLE
Feature/kobaj login manager refresh

### DIFF
--- a/src/regdesk/login/login_manager.js
+++ b/src/regdesk/login/login_manager.js
@@ -8,6 +8,45 @@ const STORAGE_LOCAL_KEY = 'regfox-bearer-details';
  * 1. Keeps the bearer token fresh and regfox status connected.
  */
 export class LoginManager {
+  static #instance;
+  /** Only one instance of LoginManager can exist. */
+  constructor() {
+    if (LoginManager.#instance) {
+      throw new Error('LoginManager already has an instance!!!');
+    }
+    LoginManager.#instance = this;
+
+    setInterval(async () => {
+      try {
+        await this.refresh();
+      } catch (e) {
+        console.error('Failed to refresh bearer token, user will need to re-login.', e);
+        await this.#setBearerDetails(null);
+      }
+    }, 1000 * 30); // 30 seconds.
+  }
+
+  /**
+   * Will refresh the bearerDetails if they are stale.
+   * @param {boolean} ignoreTtl true if this should "force" a refresh, ignoring the ttl timeout.
+   */
+  async refresh(ignoreTtl = false) {
+    const bearerDetails = await this.#getBearerDetails();
+    if (bearerDetails == null) {
+      return;
+    }
+
+    const now = new Date();
+    const oneMinuteFromNow = now.setMinutes(now.getMinutes() + 1);
+    if (bearerDetails.ttl > oneMinuteFromNow && !ignoreTtl) {
+      return;
+    }
+
+    const response = await RegfoxApi.exchangeBearerToken(bearerDetails.bearerToken);
+    const ttl = now.setSeconds(now.getSeconds() + response.ttl);
+    await this.#setBearerDetails(this.#makeBearerDetails(response.token, ttl));
+  }
+
   /**
    * @return {*} the full bearerDetails, which includes the bearerToken, and TTL.
    */
@@ -50,10 +89,18 @@ export class LoginManager {
    */
   async login(email, password) {
     const loginResponse = await RegfoxApi.login(email, password);
-    const now = new Date();
-    const ttl = now.setMinutes(now.getMinutes() + 10);
-    const bearerDetails = { bearerToken: loginResponse.token.token, ttl };
+    const bearerDetails = this.#makeBearerDetails(loginResponse.token.token);
 
     await this.#setBearerDetails(bearerDetails);
+    await this.refresh(/* ignoreTtl= */ true);
+  }
+
+  /**
+   * @param {string} bearerToken from login.
+   * @param {*} ttl the time (in milliseconds since epoch) this bearerToken expires.
+   * @return {*} bearerDetails.
+   */
+  #makeBearerDetails(bearerToken, ttl = (new Date()).setMinutes((new Date()).getMinutes() + 10)) {
+    return { bearerToken, ttl };
   }
 }

--- a/src/regdesk/login/login_manager.js
+++ b/src/regdesk/login/login_manager.js
@@ -1,4 +1,4 @@
-import { login } from '../../regfox/regfox_api.js';
+import { RegfoxApi } from '../../regfox/regfox_api.js';
 
 const STORAGE_LOCAL_KEY = 'regfox-bearer-details';
 
@@ -19,7 +19,6 @@ export class LoginManager {
    * @param {*} bearerDetails which includes the bearerToken, and the TTL.
    */
   async #setBearerDetails(bearerDetails) {
-    console.log(bearerDetails);
     await chrome.storage.local.set({ [STORAGE_LOCAL_KEY]: bearerDetails });
   }
 
@@ -50,7 +49,7 @@ export class LoginManager {
    * @param {*} password from the login modal.
    */
   async login(email, password) {
-    const loginResponse = await login(email, password);
+    const loginResponse = await RegfoxApi.login(email, password);
     const now = new Date();
     const ttl = now.setMinutes(now.getMinutes() + 10);
     const bearerDetails = { bearerToken: loginResponse.token.token, ttl };

--- a/src/regfox/regfox_api.js
+++ b/src/regfox/regfox_api.js
@@ -218,10 +218,12 @@ const handleBadResponseCodes = (response) => {
   return response;
 };
 
-export {
+export const RegfoxApi = {
   getRegistrationInfo, searchRegistrations, exchangeBearerToken,
   login, markRegistrationComplete, addNote, checkIn,
+};
 
+export {
   // Only exported for testing, DONT USE THESE OTHERWISE!
   REGFOX_GRAPHQL_URL as TEST_REGFOX_GRAPHQL_URL,
   REGFOX_EXCHANGE_TOKEN_URL as TEST_REGFOX_EXCHANGE_TOKEN_URL,

--- a/test/regfox/regfox_api.integration.js
+++ b/test/regfox/regfox_api.integration.js
@@ -7,7 +7,8 @@ use(chaiAsPromised);
 should();
 const { expect } = chai;
 
-import { searchRegistrations, login, getRegistrationInfo, markRegistrationComplete, addNote, checkIn } from '../../src/regfox/regfox_api.js';
+import { RegfoxApi } from '../../src/regfox/regfox_api.js';
+const { searchRegistrations, login, getRegistrationInfo, markRegistrationComplete, addNote, checkIn } = RegfoxApi;
 
 const loginForTest = async () => {
   const email = process.env.EMAIL;

--- a/test/regfox/regfox_api.test.js
+++ b/test/regfox/regfox_api.test.js
@@ -17,10 +17,9 @@ import { setupServer } from 'msw/node/lib/index.js';
 import fetch from 'node-fetch';
 global.fetch = fetch;
 
-import {
-  exchangeBearerToken, searchRegistrations, login, getRegistrationInfo,
-  markRegistrationComplete, addNote, checkIn,
-} from '../../src/regfox/regfox_api.js';
+import { RegfoxApi } from '../../src/regfox/regfox_api.js';
+const { exchangeBearerToken, searchRegistrations, login, getRegistrationInfo,
+  markRegistrationComplete, addNote, checkIn } = RegfoxApi;
 
 describe('regfox_api', () => {
   describe('searchRegistrations', () => {


### PR DESCRIPTION
The code now grabs a new bearer token ~60 seconds before the previous one expires. Its not the prettiest logic, but I was trying to follow the pattern set about in the disable_auto_logout.js file. 

Since this is the first time calling the API from the frontend, turns out we needed to make a small adjustment to the export of the API too.